### PR TITLE
revise similarity algos, change topK logic

### DIFF
--- a/graph_algorithms/algorithms/examples/cosine_nbor_ap.gsql
+++ b/graph_algorithms/algorithms/examples/cosine_nbor_ap.gsql
@@ -1,29 +1,32 @@
-CREATE QUERY cosine_nbor_ap_sub (VERTEX source) FOR GRAPH movie RETURNS (MapAccum<VERTEX, FLOAT>){
+CREATE QUERY cosine_nbor_ap_sub (VERTEX source, INT topK) FOR GRAPH movie RETURNS (MapAccum<VERTEX, FLOAT>){
 /* This subquery calculates the Cosine Similarity between a given vertex and every other vertex.
 Cosine similarity = A \dot B / ||A|| \dot ||B||
 */
 
-        MapAccum<VERTEX, FLOAT> @@result;
-        SumAccum<FLOAT> @numerator, @@norm1, @norm2;
+        MapAccum<VERTEX, FLOAT> @@topK_result;
+        SumAccum<FLOAT> @numerator, @@norm1, @norm2, @similarity;
 
-        start1 = {source};
+        start = {source};
         subjects = SELECT t
-                   FROM start1:s -(Likes:e)-> :t
+                   FROM start:s -(Likes:e)-> :t
                    ACCUM t.@numerator = e.weight,
                          @@norm1 += pow(e.weight, 2);
 
         neighbours = SELECT t
-                     FROM subjects:s -(reverse_Likes:e)-> Person:t
-                     WHERE t != source and getvid(source) < getvid(t)
+                     FROM subjects:s -(Reverse_Likes:e)-> Person:t
+                     WHERE t != source
                      ACCUM t.@numerator += s.@numerator * e.weight;
 
         neighbours = SELECT s
                      FROM neighbours:s -(Likes:e)-> :t
                      ACCUM s.@norm2 += pow(e.weight, 2)
-                     POST-ACCUM @@result += (s -> s.@numerator/sqrt(@@norm1 * s.@norm2))
-                 ;
-
-        RETURN @@result;
+                     POST-ACCUM s.@similarity = s.@numerator/sqrt(@@norm1 * s.@norm2)
+                     ORDER BY s.@similarity DESC
+                     LIMIT topK;
+        neighbours = SELECT s
+                     FROM neighbours:s 
+                     ACCUM @@topK_result += (s -> s.@similarity);
+        return @@topK_result;
 }
 
 
@@ -33,23 +36,11 @@ CREATE QUERY cosine_nbor_ap (INT topK) FOR GRAPH movie{
 2. The Attribute version insert edges between the pairs, with the score as an edge attribute.
    A similarity edge with one FLOAT attribute in the schema is required for this version.
 */
-        TYPEDEF tuple<VERTEX vertex1, VERTEX vertex2, FLOAT score> SIMILARITY_SCORE;
-        MapAccum<VERTEX, FLOAT> @single_result;
-        HeapAccum<SIMILARITY_SCORE>(topK, score DESC) @@total_result;
-
+        MapAccum<VERTEX, FLOAT> @result;
         start = {Person.*}; 
         start = SELECT s
                 FROM start:s
-                ACCUM s.@single_result = cosine_nbor_ap_sub (s)
-                POST-ACCUM 
-                        FOREACH (key, value) IN s.@single_result DO
-                                @@total_result += SIMILARITY_SCORE(s, key, value)
-                        END
-            ;
-        
-        PRINT @@total_result;
-
+                ACCUM s.@result = cosine_nbor_ap_sub(s, topK);
+        PRINT start.@result;
 }
 
-#install query cosine_nbor_ap_sub
-#install query cosine_nbor_ap 

--- a/graph_algorithms/algorithms/examples/cosine_nbor_ap_attr.gsql
+++ b/graph_algorithms/algorithms/examples/cosine_nbor_ap_attr.gsql
@@ -3,31 +3,28 @@
 Cosine similarity = A \dot B / ||A|| \dot ||B||
 */
 
-        SumAccum<FLOAT> @numerator, @@norm1, @norm2;
-        SumAccum<FLOAT> @cosine;
+        SumAccum<FLOAT> @numerator, @@norm1, @norm2, @similarity;
 
-        start1 = {source};
+        start = {source};
         subjects = SELECT t
-                   FROM start1:s -(Likes:e)-> :t
+                   FROM start:s -(Likes:e)-> :t
                    ACCUM t.@numerator = e.weight,
                          @@norm1 += pow(e.weight, 2);
 
         neighbours = SELECT t
-                     FROM subjects:s -(reverse_Likes:e)-> Person:t
-                     WHERE t != source and getvid(source) < getvid(t)
+                     FROM subjects:s -(Reverse_Likes:e)-> Person:t
+                     WHERE t != source
                      ACCUM t.@numerator += s.@numerator * e.weight;
 
         neighbours = SELECT s
                      FROM neighbours:s -(Likes:e)-> :t
                      ACCUM s.@norm2 += pow(e.weight, 2)
-                     POST-ACCUM s.@cosine = s.@numerator/sqrt(@@norm1 * s.@norm2)
-                     ORDER BY s.@cosine DESC
-                     LIMIT topK
-                 ;
+                     POST-ACCUM s.@similarity = s.@numerator/sqrt(@@norm1 * s.@norm2)
+                     ORDER BY s.@similarity DESC
+                     LIMIT topK;
         neighbours = SELECT s
                      FROM neighbours:s
-                     POST-ACCUM insert into similarity values(source, s, s.@cosine);
-
+                     POST-ACCUM insert into Similarity values(source, s, s.@similarity);
 }
 
 
@@ -37,15 +34,9 @@ CREATE QUERY cosine_nbor_ap_attr (INT topK) FOR GRAPH movie {
 2. The Attribute version insert edges between the pairs, with the score as an edge attribute.
    A similarity edge with one FLOAT attribute in the schema is required for this version.
 */
-
         start = {Person.*}; 
         start = SELECT s
                 FROM start:s
-                ACCUM cosine_nbor_ap_sub_attr (s, topK)
-            ;
-        
-
+                ACCUM cosine_nbor_ap_sub_attr(s, topK);
 }
 
-#install query cosine_nbor_ap_sub_attr
-#install query cosine_nbor_ap_attr 

--- a/graph_algorithms/algorithms/examples/cosine_nbor_ap_file.gsql
+++ b/graph_algorithms/algorithms/examples/cosine_nbor_ap_file.gsql
@@ -1,59 +1,43 @@
-  CREATE QUERY cosine_nbor_ap_sub_file (VERTEX source) FOR GRAPH movie RETURNS (MapAccum<VERTEX, FLOAT>){
+  CREATE QUERY cosine_nbor_ap_sub_file (VERTEX source, INT topK, FILE f) FOR GRAPH movie{
 /* This subquery calculates the Cosine Similarity between a given vertex and every other vertex.
 Cosine similarity = A \dot B / ||A|| \dot ||B||
 */
 
-        MapAccum<VERTEX, FLOAT> @@result;
-        SumAccum<FLOAT> @numerator, @@norm1, @norm2;
+        SumAccum<FLOAT> @numerator, @@norm1, @norm2, @similarity;
 
-        start1 = {source};
+        start = {source};
         subjects = SELECT t
-                   FROM start1:s -(Likes:e)-> :t
+                   FROM start:s -(Likes:e)-> :t
                    ACCUM t.@numerator = e.weight,
                          @@norm1 += pow(e.weight, 2);
 
         neighbours = SELECT t
-                     FROM subjects:s -(reverse_Likes:e)-> Person:t
-                     WHERE t != source and getvid(source) < getvid(t)
+                     FROM subjects:s -(Reverse_Likes:e)-> Person:t
+                     WHERE t != source
                      ACCUM t.@numerator += s.@numerator * e.weight;
 
         neighbours = SELECT s
                      FROM neighbours:s -(Likes:e)-> :t
                      ACCUM s.@norm2 += pow(e.weight, 2)
-                     POST-ACCUM @@result += (s -> s.@numerator/sqrt(@@norm1 * s.@norm2))
-                 ;
-
-        RETURN @@result;
+                     POST-ACCUM s.@similarity = s.@numerator/sqrt(@@norm1 * s.@norm2)
+                     ORDER BY s.@similarity DESC
+                     LIMIT topK;
+        neighbours = SELECT s
+                     FROM neighbours:s
+                     POST-ACCUM f.println(source, s, s.@similarity);
 }
 
 
-      CREATE QUERY cosine_nbor_ap_file (INT topK, STRING filepath) FOR GRAPH movie{
+      CREATE QUERY cosine_nbor_ap_file (INT topK, FILE f) FOR GRAPH movie{
 /* This query calls the subquery cosine_nbor_ap_sub_file to get the similarity score of every pair of vertices.
 1. The JSON and FILE version keeps the top k pairs of vertices. The result in FILE version is not in order.
 2. The Attribute version insert edges between the pairs, with the score as an edge attribute.
    A similarity edge with one FLOAT attribute in the schema is required for this version.
 */
-        TYPEDEF tuple<VERTEX vertex1, VERTEX vertex2, FLOAT score> SIMILARITY_SCORE;
-        FILE f(filepath);
-        MapAccum<VERTEX, FLOAT> @single_result;
-        HeapAccum<SIMILARITY_SCORE>(topK, score DESC) @@total_result;
-
         start = {Person.*}; 
+        f.println("Vertex1","Vertex2","Similarity");
         start = SELECT s
                 FROM start:s
-                ACCUM s.@single_result = cosine_nbor_ap_sub_file (s)
-                POST-ACCUM
-                        FOREACH (key, value) IN s.@single_result DO
-                                @@total_result += SIMILARITY_SCORE(s, key, value)
-                        END
-            ;
-        
-        f.println("Vertex1","Vertex2","Similarity");
-        FOREACH item IN @@total_result DO
-                f.println(item.vertex1, item.vertex2, item.score);
-        END;
-
+                ACCUM cosine_nbor_ap_sub_file(s, topK, f);
 }
 
-#install query cosine_nbor_ap_sub_file
-#install query cosine_nbor_ap_file 

--- a/graph_algorithms/algorithms/examples/cosine_nbor_ss.gsql
+++ b/graph_algorithms/algorithms/examples/cosine_nbor_ss.gsql
@@ -5,15 +5,11 @@ Cosine similarity = A \dot B / ||A|| \dot ||B||
 2. The Attribute version insert edges between the pairs, with the score as an edge attribute.
    A similarity edge with one FLOAT attribute in the schema is required for this version.
 */
+        SumAccum<FLOAT> @numerator, @@norm1, @norm2, @similarity;
 
-        TYPEDEF tuple<VERTEX vertex1, VERTEX vertex2, FLOAT score> SIMILARITY_SCORE;
-
-        HeapAccum<SIMILARITY_SCORE>(topK, score DESC) @@result_topK;    
-        SumAccum<FLOAT> @numerator, @@norm1, @norm2;
-
-        start1 = {source};
+        start = {source};
         subjects = SELECT t
-                   FROM start1:s -(Likes:e)-> :t
+                   FROM start:s -(Likes:e)-> :t
                    ACCUM t.@numerator = e.weight,
                          @@norm1 += pow(e.weight, 2);
 
@@ -25,10 +21,12 @@ Cosine similarity = A \dot B / ||A|| \dot ||B||
         neighbours = SELECT s
                      FROM neighbours:s -(Likes:e)-> :t
                      ACCUM s.@norm2 += pow(e.weight, 2)
-              	     POST-ACCUM @@result_topK += SIMILARITY_SCORE(source, s, s.@numerator/sqrt(@@norm1 * s.@norm2))
-                     ;
+        	     POST-ACCUM s.@similarity = s.@numerator/sqrt(@@norm1 * s.@norm2)
+                     ORDER BY s.@similarity DESC
+                     LIMIT topK;
 
-        PRINT @@result_topK;
+
+        PRINT neighbours.@similarity;
 
 
 }

--- a/graph_algorithms/algorithms/examples/cosine_nbor_ss_attr.gsql
+++ b/graph_algorithms/algorithms/examples/cosine_nbor_ss_attr.gsql
@@ -1,36 +1,33 @@
-CREATE QUERY cosine_nbor_ss_attr (vertex<Person> source, INT topK) FOR GRAPH movie {
+CREATE QUERY cosine_nbor_ss_attr (VERTEX<Person> source, INT topK) FOR GRAPH movie {
 /* This query calculates the Cosine Similarity between a given vertex and every other vertex.
 Cosine similarity = A \dot B / ||A|| \dot ||B||
 1. The JSON and FILE version keeps the top k pairs of vertices. The result in FILE version is not in order.
 2. The Attribute version insert edges between the pairs, with the score as an edge attribute.
    A similarity edge with one FLOAT attribute in the schema is required for this version.
 */
+        SumAccum<FLOAT> @numerator, @@norm1, @norm2, @similarity;
 
-
-        SumAccum<FLOAT> @numerator, @@norm1, @norm2;
-        SumAccum<FLOAT> @cosine;
-
-        start1 = {source};
+        start = {source};
         subjects = SELECT t
-                   FROM start1:s -(Likes:e)-> :t
+                   FROM start:s -(Likes:e)-> :t
                    ACCUM t.@numerator = e.weight,
                          @@norm1 += pow(e.weight, 2);
 
         neighbours = SELECT t
-                     FROM subjects:s -(reverse_Likes:e)-> Person:t
+                     FROM subjects:s -(Reverse_Likes:e)-> Person:t
                      WHERE t != source
                      ACCUM t.@numerator += s.@numerator * e.weight;
 
         neighbours = SELECT s
                      FROM neighbours:s -(Likes:e)-> :t
                      ACCUM s.@norm2 += pow(e.weight, 2)
-              	     POST-ACCUM s.@cosine = s.@numerator/sqrt(@@norm1 * s.@norm2)
-                     ORDER BY s.@cosine DESC
-                     LIMIT topK
-                     ;
+        	     POST-ACCUM s.@similarity = s.@numerator/sqrt(@@norm1 * s.@norm2)
+                     ORDER BY s.@similarity DESC
+                     LIMIT topK;
+
         neighbours = SELECT s
                      FROM neighbours:s
-                     POST-ACCUM insert into similarity values(source, s, s.@cosine);
+                     POST-ACCUM insert into Similarity values(source, s, s.@similarity);
 
 
 

--- a/graph_algorithms/algorithms/examples/cosine_nbor_ss_file.gsql
+++ b/graph_algorithms/algorithms/examples/cosine_nbor_ss_file.gsql
@@ -1,39 +1,36 @@
-      CREATE QUERY cosine_nbor_ss_file (VERTEX source, INT topK, STRING filepath) FOR GRAPH movie {
+      CREATE QUERY cosine_nbor_ss_file (VERTEX source, INT topK, FILE f) FOR GRAPH movie {
 /* This query calculates the Cosine Similarity between a given vertex and every other vertex.
 Cosine similarity = A \dot B / ||A|| \dot ||B||
 1. The JSON and FILE version keeps the top k pairs of vertices. The result in FILE version is not in order.
 2. The Attribute version insert edges between the pairs, with the score as an edge attribute.
    A similarity edge with one FLOAT attribute in the schema is required for this version.
 */
+        SumAccum<FLOAT> @numerator, @@norm1, @norm2, @similarity;
 
-        TYPEDEF tuple<VERTEX vertex1, VERTEX vertex2, FLOAT score> SIMILARITY_SCORE;
-        FILE f(filepath);
-
-        HeapAccum<SIMILARITY_SCORE>(topK, score DESC) @@result_topK;
-        SumAccum<FLOAT> @numerator, @@norm1, @norm2;
-
-        start1 = {source};
+        start = {source};
         subjects = SELECT t
-                   FROM start1:s -(Likes:e)-> :t
+                   FROM start:s -(Likes:e)-> :t
                    ACCUM t.@numerator = e.weight,
                          @@norm1 += pow(e.weight, 2);
 
         neighbours = SELECT t
-                     FROM subjects:s -(reverse_Likes:e)-> Person:t
+                     FROM subjects:s -(Reverse_Likes:e)-> Person:t
                      WHERE t != source
                      ACCUM t.@numerator += s.@numerator * e.weight;
 
         neighbours = SELECT s
                      FROM neighbours:s -(Likes:e)-> :t
                      ACCUM s.@norm2 += pow(e.weight, 2)
-                     POST-ACCUM @@result_topK += SIMILARITY_SCORE(source, s, s.@numerator/sqrt(@@norm1 * s.@norm2))
-                     ;
+        	     POST-ACCUM s.@similarity = s.@numerator/sqrt(@@norm1 * s.@norm2)
+                     ORDER BY s.@similarity DESC
+                     LIMIT topK;
 
 
-        f.println("Vertex1","Vertex2","Similarity");
-        FOREACH item IN @@result_topK DO
-                 f.println(item.vertex1, item.vertex2, item.score);
-        END;
+
+        f.println("Vertex1", "Vertex2", "Similarity");
+        neighbours = SELECT s 
+                     FROM neighbours:s
+                     POST-ACCUM f.println(source, s, s.@similarity);
 
 }
 

--- a/graph_algorithms/algorithms/examples/jaccard_nbor_ap.gsql
+++ b/graph_algorithms/algorithms/examples/jaccard_nbor_ap.gsql
@@ -1,10 +1,11 @@
-CREATE QUERY jaccard_nbor_ap_sub (vertex source) FOR GRAPH movie RETURNS (MapAccum<vertex, float>){
+CREATE QUERY jaccard_nbor_ap_sub (vertex source, INT topK) FOR GRAPH movie RETURNS (MapAccum<VERTEX, FLOAT>){
 /* This subquery calculates the Jaccard Similarity between a given vertex and every other vertex.
 Jaccard similarity = intersection_size / (size_A + size_B - intersection_size)
 */
     
-        MapAccum<vertex, float> @@result;
-        SumAccum<int> @intersection_size, @@set_size_A, @set_size_B;
+        MapAccum<VERTEX, FLOAT> @@topK_result;
+        SumAccum<INT> @intersection_size, @@set_size_A, @set_size_B;
+        SumAccum<FLOAT> @similarity;
 
         Start (ANY) = {source};
         Start = SELECT s
@@ -16,13 +17,16 @@ Jaccard similarity = intersection_size / (size_A + size_B - intersection_size)
 
         Others = SELECT t
                  FROM Subjects:s -(Reverse_Likes:e)- :t
-                 WHERE t != source and getvid(source) < getvid(t)
+                 WHERE t != source 
                  ACCUM t.@intersection_size += 1, 
                        t.@set_size_B = t.outdegree("Likes")
-                 POST-ACCUM @@result += (t -> t.@intersection_size*1.0/(@@set_size_A + t.@set_size_B - t.@intersection_size))
-                 ;
-
-        RETURN @@result;
+                 POST-ACCUM t.@similarity = t.@intersection_size*1.0/(@@set_size_A + t.@set_size_B - t.@intersection_size)
+                 ORDER BY t.@similarity DESC
+                 LIMIT topK;
+        Others = SELECT s
+                 FROM Others:s
+                 ACCUM @@topK_result += (s -> s.@similarity);
+        return @@topK_result;
 }
 
 CREATE QUERY jaccard_nbor_ap (INT topK) FOR GRAPH movie{
@@ -31,22 +35,11 @@ CREATE QUERY jaccard_nbor_ap (INT topK) FOR GRAPH movie{
 2. The Attribute version insert edges between the pairs, with the score as an edge attribute. 
    A similarity edge with one float attribute in the schema is required for this version.  
 */
-
-        TYPEDEF tuple<vertex vertex1, vertex vertex2, float score> SIMILARITY_SCORE;
-        MapAccum<vertex, float> @single_result;
-        HeapAccum<SIMILARITY_SCORE>(topK, score DESC) @@total_result;
-
+        MapAccum<VERTEX, FLOAT> @result;
         start = {Person.*};
         start = SELECT s
                 FROM start:s
-                ACCUM s.@single_result = jaccard_nbor_ap_sub (s)
-                POST-ACCUM
-                        FOREACH (key, value) IN s.@single_result DO
-                                @@total_result += SIMILARITY_SCORE(s, key, value)
-                        END
-                ;
-
-        PRINT @@total_result;
-
+                ACCUM s.@result = jaccard_nbor_ap_sub(s, topK);
+        PRINT start.@result;
 }
 

--- a/graph_algorithms/algorithms/examples/jaccard_nbor_ap_attr.gsql
+++ b/graph_algorithms/algorithms/examples/jaccard_nbor_ap_attr.gsql
@@ -3,8 +3,8 @@
 Jaccard similarity = intersection_size / (size_A + size_B - intersection_size)
 */
     
-        SumAccum<int> @intersection_size, @@set_size_A, @set_size_B;
-        SumAccum<FLOAT> @jaccard;
+        SumAccum<INT> @intersection_size, @@set_size_A, @set_size_B;
+        SumAccum<FLOAT> @similarity;
 
         Start (ANY) = {source};
         Start = SELECT s
@@ -16,17 +16,15 @@ Jaccard similarity = intersection_size / (size_A + size_B - intersection_size)
 
         Others = SELECT t
                  FROM Subjects:s -(Reverse_Likes:e)- :t
-                 WHERE t != source and getvid(source) < getvid(t)
+                 WHERE t != source 
                  ACCUM t.@intersection_size += 1, 
                        t.@set_size_B = t.outdegree("Likes")
-                 POST-ACCUM t.@jaccard = t.@intersection_size*1.0/(@@set_size_A + t.@set_size_B - t.@intersection_size)
-                 ORDER BY t.@jaccard DESC
-                 LIMIT topK
-                 ;
+                 POST-ACCUM t.@similarity = t.@intersection_size*1.0/(@@set_size_A + t.@set_size_B - t.@intersection_size)
+                 ORDER BY t.@similarity DESC
+                 LIMIT topK;
         Others = SELECT s
                  FROM Others:s
-                 POST-ACCUM insert into Similarity values(source, s, s.@jaccard);
-
+                 POST-ACCUM insert into Similarity values(source, s, s.@similarity);
 }
 
 CREATE QUERY jaccard_nbor_ap_attr (INT topK) FOR GRAPH movie {
@@ -35,14 +33,9 @@ CREATE QUERY jaccard_nbor_ap_attr (INT topK) FOR GRAPH movie {
 2. The Attribute version insert edges between the pairs, with the score as an edge attribute. 
    A similarity edge with one float attribute in the schema is required for this version.  
 */
-
-
         start = {Person.*};
         start = SELECT s
                 FROM start:s
-                ACCUM jaccard_nbor_ap_sub_attr (s, topK)
-                ;
-
-
+                ACCUM jaccard_nbor_ap_sub_attr(s, topK);
 }
 

--- a/graph_algorithms/algorithms/examples/jaccard_nbor_ap_file.gsql
+++ b/graph_algorithms/algorithms/examples/jaccard_nbor_ap_file.gsql
@@ -1,10 +1,10 @@
-  CREATE QUERY jaccard_nbor_ap_sub_file (vertex source) FOR GRAPH movie RETURNS (MapAccum<vertex, float>){
+  CREATE QUERY jaccard_nbor_ap_sub_file (vertex source, INT topK, FILE f) FOR GRAPH movie{
 /* This subquery calculates the Jaccard Similarity between a given vertex and every other vertex.
 Jaccard similarity = intersection_size / (size_A + size_B - intersection_size)
 */
     
-        MapAccum<vertex, float> @@result;
-        SumAccum<int> @intersection_size, @@set_size_A, @set_size_B;
+        SumAccum<INT> @intersection_size, @@set_size_A, @set_size_B;
+        SumAccum<FLOAT> @similarity;
 
         Start (ANY) = {source};
         Start = SELECT s
@@ -16,41 +16,27 @@ Jaccard similarity = intersection_size / (size_A + size_B - intersection_size)
 
         Others = SELECT t
                  FROM Subjects:s -(Reverse_Likes:e)- :t
-                 WHERE t != source and getvid(source) < getvid(t)
+                 WHERE t != source 
                  ACCUM t.@intersection_size += 1, 
                        t.@set_size_B = t.outdegree("Likes")
-                 POST-ACCUM @@result += (t -> t.@intersection_size*1.0/(@@set_size_A + t.@set_size_B - t.@intersection_size))
-                 ;
-
-        RETURN @@result;
+                 POST-ACCUM t.@similarity = t.@intersection_size*1.0/(@@set_size_A + t.@set_size_B - t.@intersection_size)
+                 ORDER BY t.@similarity DESC
+                 LIMIT topK;
+        Others = SELECT s
+                 FROM Others:s
+                 POST-ACCUM f.println(source, s, s.@similarity);
 }
 
-      CREATE QUERY jaccard_nbor_ap_file (INT topK, STRING filepath) FOR GRAPH movie{
+      CREATE QUERY jaccard_nbor_ap_file (INT topK, FILE f) FOR GRAPH movie{
 /* This query calls the subquery jaccard_nbor_ap_sub_file to get the similarity score of every pair of vertices.
 1. The JSON and FILE version keeps the top k pairs of vertices. The result in FILE version is not in order.
 2. The Attribute version insert edges between the pairs, with the score as an edge attribute. 
    A similarity edge with one float attribute in the schema is required for this version.  
 */
-
-        TYPEDEF tuple<vertex vertex1, vertex vertex2, float score> SIMILARITY_SCORE;
-        FILE f(filepath);
-        MapAccum<vertex, float> @single_result;
-        HeapAccum<SIMILARITY_SCORE>(topK, score DESC) @@total_result;
-
         start = {Person.*};
+        f.println("Vertex1","Vertex2","Similarity");
         start = SELECT s
                 FROM start:s
-                ACCUM s.@single_result = jaccard_nbor_ap_sub_file (s)
-                POST-ACCUM
-                        FOREACH (key, value) IN s.@single_result DO
-                                @@total_result += SIMILARITY_SCORE(s, key, value)
-                        END
-                ;
-
-        f.println("Vertex1","Vertex2","Similarity");
-        FOREACH item IN @@total_result DO
-                f.println(item.vertex1, item.vertex2, item.score);
-        END;
-
+                ACCUM jaccard_nbor_ap_sub_file(s, topK, f);
 }
 

--- a/graph_algorithms/algorithms/examples/jaccard_nbor_ss.gsql
+++ b/graph_algorithms/algorithms/examples/jaccard_nbor_ss.gsql
@@ -5,11 +5,8 @@ Jaccard similarity = intersection_size / (size_A + size_B - intersection_size)
 2. The Attribute version insert edges between the pairs, with the score as an edge attribute.
    A similarity edge with one FLOAT attribute in the schema is required for this version.
 */
-
-        TYPEDEF tuple<VERTEX vertex1, VERTEX vertex2, FLOAT score> SIMILARITY_SCORE;
-
-        HeapAccum<SIMILARITY_SCORE>(topK, score DESC) @@result_topK;
-        SumAccum<int> @intersection_size, @@set_size_A, @set_size_B;
+        SumAccum<INT> @intersection_size, @@set_size_A, @set_size_B;
+        SumAccum<FLOAT> @similarity;
 
         Start (ANY) = {source};
         Start = SELECT s
@@ -20,14 +17,17 @@ Jaccard similarity = intersection_size / (size_A + size_B - intersection_size)
                    FROM Start:s-(Likes:e)-:t;
 
         Others = SELECT t
-                 FROM Subjects:s -(reverse_Likes:e)- :t
+                 FROM Subjects:s -(Reverse_Likes:e)- :t
                  WHERE t != source
                  ACCUM t.@intersection_size += 1,
                        t.@set_size_B = t.outdegree("Likes")
-                 POST-ACCUM @@result_topK += SIMILARITY_SCORE(source, t, t.@intersection_size*1.0/(@@set_size_A + t.@set_size_B - t.@intersection_size))
-                 ;
+                 POST-ACCUM t.@similarity = t.@intersection_size*1.0/(@@set_size_A + t.@set_size_B - t.@intersection_size)
+                 ORDER BY t.@similarity DESC
+                 LIMIT topK;
 
-        PRINT @@result_topK;
+
+        PRINT Others.@similarity;
+
 
 }
 

--- a/graph_algorithms/algorithms/examples/jaccard_nbor_ss_attr.gsql
+++ b/graph_algorithms/algorithms/examples/jaccard_nbor_ss_attr.gsql
@@ -5,10 +5,8 @@ Jaccard similarity = intersection_size / (size_A + size_B - intersection_size)
 2. The Attribute version insert edges between the pairs, with the score as an edge attribute.
    A similarity edge with one FLOAT attribute in the schema is required for this version.
 */
-
-
-        SumAccum<int> @intersection_size, @@set_size_A, @set_size_B;
-        SumAccum<FLOAT> @jaccard;
+        SumAccum<INT> @intersection_size, @@set_size_A, @set_size_B;
+        SumAccum<FLOAT> @similarity;
 
         Start (ANY) = {source};
         Start = SELECT s
@@ -19,17 +17,18 @@ Jaccard similarity = intersection_size / (size_A + size_B - intersection_size)
                    FROM Start:s-(Likes:e)-:t;
 
         Others = SELECT t
-                 FROM Subjects:s -(reverse_Likes:e)- :t
+                 FROM Subjects:s -(Reverse_Likes:e)- :t
                  WHERE t != source
                  ACCUM t.@intersection_size += 1,
                        t.@set_size_B = t.outdegree("Likes")
-                 POST-ACCUM t.@jaccard = t.@intersection_size*1.0/(@@set_size_A + t.@set_size_B - t.@intersection_size)
-                 ORDER BY t.@jaccard DESC
-                 LIMIT topK
-                 ;
+                 POST-ACCUM t.@similarity = t.@intersection_size*1.0/(@@set_size_A + t.@set_size_B - t.@intersection_size)
+                 ORDER BY t.@similarity DESC
+                 LIMIT topK;
+
         Others = SELECT s
                  FROM Others:s
-                 POST-ACCUM insert into similarity values(source, s, s.@jaccard);
+                 POST-ACCUM insert into Similarity values(source, s, s.@similarity);
+
 
 
 }

--- a/graph_algorithms/algorithms/examples/jaccard_nbor_ss_file.gsql
+++ b/graph_algorithms/algorithms/examples/jaccard_nbor_ss_file.gsql
@@ -1,16 +1,12 @@
-      CREATE QUERY jaccard_nbor_ss_file (VERTEX source, INT topK, STRinG filepath) FOR GRAPH movie {
+      CREATE QUERY jaccard_nbor_ss_file (VERTEX source, INT topK, FILE f) FOR GRAPH movie {
 /* This query calculates the Jaccard Similarity between a given vertex and every other vertex.
 Jaccard similarity = intersection_size / (size_A + size_B - intersection_size)
 1. The JSON and FILE version keeps the top k pairs of vertices. The result in FILE version is not in order.
 2. The Attribute version insert edges between the pairs, with the score as an edge attribute.
    A similarity edge with one FLOAT attribute in the schema is required for this version.
 */
-
-        TYPEDEF tuple<VERTEX vertex1, VERTEX vertex2, FLOAT score> SIMILARITY_SCORE;
-        FILE f(filepath);
-
-        HeapAccum<SIMILARITY_SCORE>(topK, score DESC) @@result_topK;
-        SumAccum<int> @intersection_size, @@set_size_A, @set_size_B;
+        SumAccum<INT> @intersection_size, @@set_size_A, @set_size_B;
+        SumAccum<FLOAT> @similarity;
 
         Start (ANY) = {source};
         Start = SELECT s
@@ -21,17 +17,20 @@ Jaccard similarity = intersection_size / (size_A + size_B - intersection_size)
                    FROM Start:s-(Likes:e)-:t;
 
         Others = SELECT t
-                 FROM Subjects:s -(reverse_Likes:e)- :t
+                 FROM Subjects:s -(Reverse_Likes:e)- :t
                  WHERE t != source
                  ACCUM t.@intersection_size += 1,
                        t.@set_size_B = t.outdegree("Likes")
-                 POST-ACCUM @@result_topK += SIMILARITY_SCORE(source, t, t.@intersection_size*1.0/(@@set_size_A + t.@set_size_B - t.@intersection_size))
-                 ;
+                 POST-ACCUM t.@similarity = t.@intersection_size*1.0/(@@set_size_A + t.@set_size_B - t.@intersection_size)
+                 ORDER BY t.@similarity DESC
+                 LIMIT topK;
 
 
-        f.println("Vertex1","Vertex2","Similarity");
-        FOREACH item IN @@result_topK DO
-                f.println(item.vertex1, item.vertex2, item.score);
-        END;
+
+        f.println("Vertex1", "Vertex2", "Similarity");
+        Others = SELECT s
+                 FROM Others:s
+                 POST-ACCUM f.println(source, s, s.@similarity);
+
 }
 

--- a/graph_algorithms/algorithms/examples/louvain.gsql
+++ b/graph_algorithms/algorithms/examples/louvain.gsql
@@ -1,80 +1,295 @@
-CREATE QUERY louvain () FOR GRAPH social {
-# Louvain Modularity Method for Community Detection
+CREATE QUERY louvain(INT iter1 = 10, INT iter2 = 10, INT iter3 = 10, INT split = 10, INT distribution = 0, INT debug = 2 ) FOR GRAPH social {
+ /*
+ * Parallel Louvain Method with Refinement
+ * https://arxiv.org/pdf/1304.4453
+ * The minimum label heuristics are implemented: https://doi.org/10.1016/j.parco.2015.03.003
+ 
+ * iter: There are three phases in the algorithm -- move, merge and refine. Their max number of iterations are set by iter1, iter2, iter3 respectively.
+ * split: To save memory, split number is 10 by default. When the split number is larger, the query is closer to sequential Louvain Method, which is slower. When the split number is 1, the query is parallel, but requires more memory. 
+ * distribution: 0, only list number; 1, also list members
+ * debug: 0, no modularity info; 1, show debug log; 2, modularity for each iteration
+ * f_community, f_distribution: files to store community label and community distribution
+*/
+        
+        TYPEDEF TUPLE <INT csize, INT number> ClusterNum;
+        TYPEDEF TUPLE <VERTEX node, INT cid, FLOAT deltaQ> vDeltaQ;
+        HeapAccum<vDeltaQ>(1, deltaQ DESC, cid ASC) @largestDeltaQ;   # if deltaQ is the same, select the one with mininal vid 
+        MapAccum<INT, FLOAT> @@totIncidentCluster;   # sun of weight incident to clusters
+        MapAccum<INT, INT> @@clusterSizes;                # size of a cluster
+        MapAccum<INT, FLOAT> @weightToCluster;  # weight from one vertex incident to that cluster
+        SumAccum<FLOAT> @@totalWeight;   # total weight of all edges
+        SumAccum<FLOAT> @weight;          # total weight incident to this vertex
+        SumAccum<FLOAT> @cweight;       # total weight incident to this aggregate vertex
+        SumAccum<INT> @uid;        # which vertex it belongs to
+        SumAccum<INT> @cid;        # which cluster it belongs to
+        SumAccum<INT> @vid;        # internal id
+        SumAccum<FLOAT> @deltaQ;         # contribution to the modularity
+        SumAccum<FLOAT> @@modularity;
+        SumAccum<FLOAT> @@modularity2;
+        MapAccum<INT, MapAccum<INT, FLOAT>> @@weightToClusterMap;   # calculate edges between communities 
+        MapAccum<INT, SetAccum<INT>> @@moveComm; # map of communities that changed its community id
+        MapAccum<INT, MinAccum<VERTEX>> @@representMap;
+        SetAccum<VERTEX> @@representSet;
+        MapAccum<INT, FLOAT> @@vertexMap;
+        MapAccum<INT, MapAccum<INT, FLOAT>> @@edgeMap;
+        HeapAccum<ClusterNum>(100, csize ASC) @@clusterDist;
+        MapAccum<INT, INT> @@clusterMap;
+        MapAccum<INT, ListAccum<INT>> @@clusterMembers;
+        FLOAT last_modularity = 0;
+        FLOAT last_modularity2 = 0;
+        INT iteration;
+        INT Iter1; 
+        FLOAT epsilon = 0.0001;
+        INT iteration2;
+        INT partitions;
+        INT loop;
 
-        # map: <cluster ID, value>
-        MapAccum<int, int> @@edgeCntWithinCluster;     # edge count inside clusters
-        MapAccum<int, int> @@edgeCntIncidentCluster;   # edge count incident to clusters
-        MapAccum<int, int> @@compSizes;                # size of a cluster
-        MapAccum<int, int> @clusterEdgeCnt;  # edge count incident to that cluster
-
-        SumAccum<int> @@totalNumEdges;   # total number of edges
-        SumAccum<int> @edgeCnt;          # total edge count of vertex
-        SumAccum<int> @cluster;        # which cluster it belongs to
-        SumAccum<float> @deltaQ;         # contribution to the modularity
-
-        OrAccum @@changed;               # true if cluster membership changed in this iterator
-  
-        Start = {ANY};
-
+        partitions = split;
+        CASE WHEN split < 1 THEN
+                partitions = 1;
+        END;
+        
 # Initialize: count edges and set a unique cluster ID for each vertex
-        Start = SELECT s 
-                FROM Start:s -(Coworker:e)-> :t
-                ACCUM @@totalNumEdges += 1,
-                      s.@edgeCnt += 1
-                POST-ACCUM s.@cluster = getvid(s); # Label each vertex with its own internal ID
-        @@changed = true;
+        Start = {Person.*};
+        S = SELECT s 
+            FROM Start:s -(Friend:e)-> :t
+            ACCUM @@totalWeight += e.weight,
+                  s.@weight += e.weight
+            POST-ACCUM s.@vid = getvid(s),
+                       s.@uid = s.@vid,
+                       s.@cid = s.@vid;  # Label each vertex with its own internal ID
 
+# Special first iteration of Phase 1
+        iteration = 1;
+        S = SELECT s 
+            FROM Start:s -(Friend:e)-> :t
+            #WHERE s.@cid != t.@cid  # since the default bestCluster is itself, don't need to calculate itself        
+            WHERE s.@cid > t.@cid
+            ACCUM s.@largestDeltaQ += vDeltaQ(t, t.@cid, e.weight - 2 * s.@weight * s.@weight/ @@totalWeight) # weightToCluster is just e.weight
+            POST-ACCUM INT bestCluster = s.@largestDeltaQ.top().cid,
+                       IF s.@largestDeltaQ.size() > 0 and s.@largestDeltaQ.top().deltaQ > 0 and s.@cid != bestCluster THEN 
+                               s.@cid = bestCluster
+                       END,
+                       s.@largestDeltaQ.clear();
+        
+        S = SELECT s
+            FROM Start:s-(Friend:e)-:t
+            WHERE s.@cid == t.@cid
+            ACCUM @@modularity += e.weight - s.@weight * t.@weight / (@@totalWeight);
+
+        @@modularity = @@modularity / @@totalWeight;                      
+        PRINT iteration AS Phase1Iter, @@modularity;
+        log(debug > 0, "[redrain]#move", iteration, @@modularity);
+        
+# Phase 1 -- Move
 # For each vertex, calculate the change in modularity FROM adding it to each of the nearby clusters
 # Add vertex to cluster with highest positive change in modularity
 # Repeat the above until no vertices change cluster anymore
-        WHILE @@changed == true DO
-                @@changed = false;
-                Start = SELECT s 
-                        FROM Start:s -(Coworker:e)-> :t
-                        ACCUM s.@clusterEdgeCnt += (t.@cluster->1),
-                                // if this is an incident edge
-                              IF s.@cluster != t.@cluster THEN
-                                      @@edgeCntIncidentCluster += (s.@cluster->1)
-                              ELSE
-                                      @@edgeCntWithinCluster += (s.@cluster->1)
-                              END
-                        POST-ACCUM
-                                INT resultCluster = s.@cluster,
-                                INT m = @@totalNumEdges,
-                                FLOAT maxDeltaQ = -999,
-                                FLOAT deltaQ_new = 0,
-                                FOREACH (cluster, edgeCnt) IN s.@clusterEdgeCnt DO
-                                        INT within = @@edgeCntWithinCluster.get(cluster),
-                                        INT incident = @@edgeCntIncidentCluster.get(cluster),
-                                        deltaQ_new = ((within + s.@clusterEdgeCnt.get(cluster)) / (2.0*m))
-                                                     - pow((incident + s.@edgeCnt)/(2.0*m),2)
-                                                     - (within / (2.0*m)
-                                                     - pow((incident/(2.0*m)),2)
-                                                     - pow((s.@edgeCnt/(2.0*m)),2)),
-                                        IF deltaQ_new > maxDeltaQ AND deltaQ_new > s.@deltaQ AND deltaQ_new > 0 THEN
-                                                maxDeltaQ = deltaQ_new,
-                                                resultCluster = cluster
-                                        END
-                                END,
-                                IF s.@cluster != resultCluster THEN
-                                        s.@cluster = resultCluster,
-                                        s.@deltaQ = maxDeltaQ,
-                                        @@changed += true
-                                END,
-                                s.@clusterEdgeCnt.clear()
-                        ;
-                @@edgeCntWithinCluster.clear();
-                @@edgeCntIncidentCluster.clear();
+        S = SELECT s 
+            FROM Start:s
+            ACCUM @@totIncidentCluster += (s.@cid -> s.@weight); 
+              
+        iteration = 1;
+        Iter1 = iter1 - 1;
+              
+        WHILE (iteration < 2 OR @@modularity - last_modularity > epsilon) LIMIT Iter1 DO
+                iteration += 1;
+                loop = 0;
+                WHILE (loop < partitions) DO 
+                        S = SELECT s 
+                            FROM Start:s -(Friend:e)-> :t
+                            WHERE s.@uid % partitions == loop AND abs(s.@weight - @@totIncidentCluster.get(s.@cid)) > epsilon OR abs(t.@weight - @@totIncidentCluster.get(t.@cid)) > epsilon OR (abs(s.@weight - @@totIncidentCluster.get(s.@cid)) < epsilon AND abs(t.@weight - @@totIncidentCluster.get(t.@cid)) < epsilon AND s.@cid > t.@cid)   # at least one cluster not only itself, or use smaller label
+                            ACCUM s.@weightToCluster += (t.@cid -> e.weight)
+                            POST-ACCUM INT bestCluster = s.@cid,
+                                       FLOAT maxDeltaQ = 0.0,
+                                       FLOAT deltaQ_new = 0.0,
+                                       FOREACH (cluster, weightToC) IN s.@weightToCluster DO   #would be better if this can be distributed
+                                               FLOAT incident = @@totIncidentCluster.get(cluster),
+                                               deltaQ_new = weightToC - 2 * incident * s.@weight/ @@totalWeight,
+                                               IF deltaQ_new > maxDeltaQ OR (abs(deltaQ_new - maxDeltaQ) < epsilon AND cluster < bestCluster) THEN   # when deltaQ_new is equal to maxDeltaQ, and the cluster label is smaller, also change 
+                                                       maxDeltaQ = deltaQ_new,
+                                                       bestCluster = cluster
+                                               END
+                                       END,
+                                       IF s.@cid != bestCluster THEN 
+                                               @@totIncidentCluster += (s.@cid -> (-1 * s.@weight)),
+                                               @@totIncidentCluster += (bestCluster -> s.@weight),
+                                               s.@cid = bestCluster
+                                       END,
+                                       s.@weightToCluster.clear();
+                        loop = loop + 1;
+                END;
+                last_modularity = @@modularity;
+                @@modularity = 0;
+                T1 = SELECT s
+                     FROM Start:s-(Friend:e)-:t
+                     WHERE s.@cid == t.@cid
+                     ACCUM @@modularity += e.weight - s.@weight * t.@weight / (@@totalWeight);
+                @@modularity = @@modularity / @@totalWeight;                      
+                PRINT iteration AS Phase1Iter, @@modularity;
+                log(debug > 0, "[redrain]#move", iteration, @@modularity);
         END;
 
+# Phase 2 --  Merge     
+        iteration2 = 0;
+        WHILE (iteration2 < 2 OR @@modularity2 - last_modularity2 > epsilon) LIMIT iter2 DO
+                iteration2 += 1;
+                Start = SELECT s
+                        FROM Start:s
+                        ACCUM s.@uid = s.@cid;      
+                # Select the vertices with minimal internal id to represent the coarsened graph
+                Start = SELECT s
+                        FROM Start:s 
+                        ACCUM @@representMap += (s.@cid -> s);
+        
+                FOREACH (key, value) IN @@representMap DO
+                        @@representSet += value;                       
+                END;      
+                represent = {@@representSet};
+                @@representMap.clear();
+                @@representSet.clear();
+                log(debug > 0, "[redrain]#2_merge", represent.size()); #@@clusterSizes.size());
+
+            # Get @cweight from totalIncident
+                represent = SELECT s
+                            FROM represent:s
+                            ACCUM s.@cweight = @@totIncidentCluster.get(s.@uid),
+                                  @@clusterSizes += (s.@cid -> 1);
+
+                log(debug > 1, "[redrain]#2_merge", @@weightToClusterMap.size());
+                iteration = 0;
+                last_modularity = 0;
+                @@modularity = 0;
+     
+                WHILE (iteration < 2 OR @@modularity - last_modularity > epsilon) limit iter1 DO
+                        iteration += 1;
+        
+                        # Calculate.weight incident from vertex to cluster in coarsened graph; change every interation
+                        S = SELECT s
+                            FROM Start:s -(Friend:e)-:t
+                            WHERE s.@cid != t.@cid AND @@totIncidentCluster.get(s.@uid) > 0 AND @@totIncidentCluster.get(t.@cid) > 0   #@@totIncidentCluster keeps changing, can be 0
+                            ACCUM @@weightToClusterMap += (s.@uid -> (t.@cid -> e.weight));  # from s, incident to some clusters. Not consider the same cluster
+                        represent = SELECT s 
+                                    FROM represent:s
+                                    POST-ACCUM INT bestCluster = s.@cid,
+                                               FLOAT maxDeltaQ = 0.0,
+                                               FLOAT deltaQ_new = 0.0,
+                                               FOREACH (cluster, weightToC) IN @@weightToClusterMap.get(s.@uid) DO 
+                                                       FLOAT incident = @@totIncidentCluster.get(cluster),
+                                                       IF @@clusterSizes.get(s.@cid) == 1 AND @@clusterSizes.get(cluster) == 1 AND s.@cid < cluster THEN
+                                                               CONTINUE
+                                                       END,
+                                                       deltaQ_new = weightToC - 2 * incident * s.@cweight/ @@totalWeight, #total weight should be the same
+                                                       IF deltaQ_new > maxDeltaQ OR abs(deltaQ_new - maxDeltaQ) < epsilon AND cluster < bestCluster THEN      # new cluster is smaller then the current best cluster
+                                                               maxDeltaQ = deltaQ_new,
+                                                               bestCluster = cluster
+                                                       END
+                                               END,
+                                               IF s.@cid != bestCluster THEN
+                                                       @@totIncidentCluster += (s.@cid -> (-1 * s.@cweight)),
+                                                       @@totIncidentCluster += (bestCluster -> s.@cweight),
+                                                       @@moveComm += (s.@uid -> bestCluster),
+                                                       @@clusterSizes += (s.@cid -> -1),
+                                                       @@clusterSizes += (bestCluster -> 1),
+                                                       s.@cid = bestCluster
+                                               END;
+                        log(debug > 1, "[redrain]#2_merge", @@weightToClusterMap.size()); 
+                        @@weightToClusterMap.clear();
+                   
+                        log(debug > 1, "[redrain]#2_move:", @@moveComm.size());
+                        # move nodes
+                        S = SELECT s
+                            FROM Start:s
+                            WHERE @@moveComm.containsKey(s.@uid)
+                            POST-ACCUM FOREACH v IN @@moveComm.get(s.@uid) DO
+                                               s.@cid = v
+                                       END;
+                        @@moveComm.clear();
+    
+                        last_modularity = @@modularity;           
+                        @@modularity = 0;
+                
+                        S = SELECT s
+                            FROM Start:s-(Friend:e)-:t
+                            WHERE s.@cid == t.@cid
+                            ACCUM @@modularity += e.weight - s.@weight * t.@weight / (@@totalWeight);
+                            @@modularity = @@modularity / @@totalWeight;
+                            PRINT iteration AS Phase1Iter, @@modularity;
+                        log(debug > 0, "[redrain]#2_move", iteration, @@modularity);
+                END;
+        
+                S = SELECT s
+                    FROM represent:s
+                    ACCUM s.@cweight = 0;
+                @@clusterSizes.clear();
+        
+                last_modularity2 = @@modularity2;
+                @@modularity2 = @@modularity;
+                PRINT iteration2 AS Phase2Iter, @@modularity2;
+                log(debug > 0, "[redrain]#2_merge", iteration2, @@modularity2);
+                                      
+        END;
+        
+        
+# Phase 3 -- Refinement
+        iteration = 0;
+        @@modularity = 0;
+        WHILE (iteration < 2 OR @@modularity - last_modularity > epsilon) LIMIT iter3 DO
+                iteration += 1;
+                S = SELECT s 
+                    FROM Start:s -(Friend:e)-> :t
+                    WHERE abs(s.@weight - @@totIncidentCluster.get(s.@cid)) > epsilon OR abs(t.@weight - @@totIncidentCluster.get(t.@cid)) > epsilon OR (abs(s.@weight - @@totIncidentCluster.get(s.@cid)) < epsilon AND abs(t.@weight - @@totIncidentCluster.get(t.@cid)) < epsilon AND s.@cid > t.@cid)   # at least one cluster not only itself, or use smaller label
+                    ACCUM s.@weightToCluster += (t.@cid -> e.weight)
+                    POST-ACCUM
+                            INT bestCluster = s.@cid,
+                            FLOAT maxDeltaQ = 0.0,
+                            FLOAT deltaQ_new = 0.0,
+                            FOREACH (cluster, weightToC) IN s.@weightToCluster DO   #would be better if this can be distributed
+                                    FLOAT incident = @@totIncidentCluster.get(cluster),
+                                    deltaQ_new = weightToC - 2 * incident * s.@weight/ @@totalWeight,
+                                    IF deltaQ_new > maxDeltaQ OR (abs(deltaQ_new - maxDeltaQ) < epsilon AND cluster < bestCluster) THEN   # when deltaQ_new is equal to maxDeltaQ, and the cluster label is smaller, also change 
+                                            maxDeltaQ = deltaQ_new,
+                                            bestCluster = cluster
+                                    END
+                            END,
+                            IF s.@cid != bestCluster THEN 
+                                    @@totIncidentCluster += (s.@cid -> (-1 * s.@weight)),
+                                    @@totIncidentCluster += (bestCluster -> s.@weight),
+                                    s.@cid = bestCluster
+                            END,
+                            s.@weightToCluster.clear();
+
+                last_modularity = @@modularity;
+                @@modularity = 0;
+                T1 = SELECT s
+                     FROM Start:s-(Friend:e)-:t
+                     WHERE s.@cid == t.@cid
+                     ACCUM @@modularity += e.weight - s.@weight * t.@weight / (@@totalWeight);
+                @@modularity = @@modularity / @@totalWeight;                      
+                PRINT iteration AS Phase3Iter, @@modularity;
+                log(debug > 0, "[redrain]#refine", iteration, @@modularity);
+        END;
+        
+                
+        Print Start.@cid;
         Start = {ANY};
-
-
         Start = SELECT s FROM Start:s
-                POST-ACCUM @@compSizes += (s.@cluster -> 1);
-        PRINT @@compSizes;
-        PRINT Start.@cluster;
+                POST-ACCUM @@clusterSizes += (s.@cid -> 1)
+                           ;
 
+
+        IF distribution ==0 THEN
+                FOREACH (cluster, csize) IN @@clusterSizes DO
+                        @@clusterMap += (csize -> 1);
+                END;
+                FOREACH (csize, number) IN @@clusterMap DO
+                        @@clusterDist += ClusterNum(csize, number);
+                END;
+                PRINT @@clusterDist;
+        ELSE
+                FOREACH (cluster, csize) IN @@clusterSizes DO
+                        @@clusterMembers += (csize -> cluster);
+                END;
+                PRINT @@clusterMembers;
+        END;
 }
-
-#INSTALL QUERY louvain

--- a/graph_algorithms/algorithms/examples/louvain_attr.gsql
+++ b/graph_algorithms/algorithms/examples/louvain_attr.gsql
@@ -1,78 +1,295 @@
-CREATE QUERY louvain_attr () FOR GRAPH social {
-# Louvain Modularity Method for Community Detection
+CREATE QUERY louvain_attr(INT iter1 = 10, INT iter2 = 10, INT iter3 = 10, INT split = 10, INT distribution = 0, INT debug = 2 ) FOR GRAPH social {
+ /*
+ * Parallel Louvain Method with Refinement
+ * https://arxiv.org/pdf/1304.4453
+ * The minimum label heuristics are implemented: https://doi.org/10.1016/j.parco.2015.03.003
+ 
+ * iter: There are three phases in the algorithm -- move, merge and refine. Their max number of iterations are set by iter1, iter2, iter3 respectively.
+ * split: To save memory, split number is 10 by default. When the split number is larger, the query is closer to sequential Louvain Method, which is slower. When the split number is 1, the query is parallel, but requires more memory. 
+ * distribution: 0, only list number; 1, also list members
+ * debug: 0, no modularity info; 1, show debug log; 2, modularity for each iteration
+ * f_community, f_distribution: files to store community label and community distribution
+*/
+        
+        TYPEDEF TUPLE <INT csize, INT number> ClusterNum;
+        TYPEDEF TUPLE <VERTEX node, INT cid, FLOAT deltaQ> vDeltaQ;
+        HeapAccum<vDeltaQ>(1, deltaQ DESC, cid ASC) @largestDeltaQ;   # if deltaQ is the same, select the one with mininal vid 
+        MapAccum<INT, FLOAT> @@totIncidentCluster;   # sun of weight incident to clusters
+        MapAccum<INT, INT> @@clusterSizes;                # size of a cluster
+        MapAccum<INT, FLOAT> @weightToCluster;  # weight from one vertex incident to that cluster
+        SumAccum<FLOAT> @@totalWeight;   # total weight of all edges
+        SumAccum<FLOAT> @weight;          # total weight incident to this vertex
+        SumAccum<FLOAT> @cweight;       # total weight incident to this aggregate vertex
+        SumAccum<INT> @uid;        # which vertex it belongs to
+        SumAccum<INT> @cid;        # which cluster it belongs to
+        SumAccum<INT> @vid;        # internal id
+        SumAccum<FLOAT> @deltaQ;         # contribution to the modularity
+        SumAccum<FLOAT> @@modularity;
+        SumAccum<FLOAT> @@modularity2;
+        MapAccum<INT, MapAccum<INT, FLOAT>> @@weightToClusterMap;   # calculate edges between communities 
+        MapAccum<INT, SetAccum<INT>> @@moveComm; # map of communities that changed its community id
+        MapAccum<INT, MinAccum<VERTEX>> @@representMap;
+        SetAccum<VERTEX> @@representSet;
+        MapAccum<INT, FLOAT> @@vertexMap;
+        MapAccum<INT, MapAccum<INT, FLOAT>> @@edgeMap;
+        HeapAccum<ClusterNum>(100, csize ASC) @@clusterDist;
+        MapAccum<INT, INT> @@clusterMap;
+        MapAccum<INT, ListAccum<INT>> @@clusterMembers;
+        FLOAT last_modularity = 0;
+        FLOAT last_modularity2 = 0;
+        INT iteration;
+        INT Iter1; 
+        FLOAT epsilon = 0.0001;
+        INT iteration2;
+        INT partitions;
+        INT loop;
 
-        # map: <cluster ID, value>
-        MapAccum<int, int> @@edgeCntWithinCluster;     # edge count inside clusters
-        MapAccum<int, int> @@edgeCntIncidentCluster;   # edge count incident to clusters
-        MapAccum<int, int> @@compSizes;                # size of a cluster
-        MapAccum<int, int> @clusterEdgeCnt;  # edge count incident to that cluster
-
-        SumAccum<int> @@totalNumEdges;   # total number of edges
-        SumAccum<int> @edgeCnt;          # total edge count of vertex
-        SumAccum<int> @cluster;        # which cluster it belongs to
-        SumAccum<float> @deltaQ;         # contribution to the modularity
-
-        OrAccum @@changed;               # true if cluster membership changed in this iterator
-  
-        Start = {ANY};
-
+        partitions = split;
+        CASE WHEN split < 1 THEN
+                partitions = 1;
+        END;
+        
 # Initialize: count edges and set a unique cluster ID for each vertex
-        Start = SELECT s 
-                FROM Start:s -(Coworker:e)-> :t
-                ACCUM @@totalNumEdges += 1,
-                      s.@edgeCnt += 1
-                POST-ACCUM s.@cluster = getvid(s); # Label each vertex with its own internal ID
-        @@changed = true;
+        Start = {Person.*};
+        S = SELECT s 
+            FROM Start:s -(Friend:e)-> :t
+            ACCUM @@totalWeight += e.weight,
+                  s.@weight += e.weight
+            POST-ACCUM s.@vid = getvid(s),
+                       s.@uid = s.@vid,
+                       s.@cid = s.@vid;  # Label each vertex with its own internal ID
 
+# Special first iteration of Phase 1
+        iteration = 1;
+        S = SELECT s 
+            FROM Start:s -(Friend:e)-> :t
+            #WHERE s.@cid != t.@cid  # since the default bestCluster is itself, don't need to calculate itself        
+            WHERE s.@cid > t.@cid
+            ACCUM s.@largestDeltaQ += vDeltaQ(t, t.@cid, e.weight - 2 * s.@weight * s.@weight/ @@totalWeight) # weightToCluster is just e.weight
+            POST-ACCUM INT bestCluster = s.@largestDeltaQ.top().cid,
+                       IF s.@largestDeltaQ.size() > 0 and s.@largestDeltaQ.top().deltaQ > 0 and s.@cid != bestCluster THEN 
+                               s.@cid = bestCluster
+                       END,
+                       s.@largestDeltaQ.clear();
+        
+        S = SELECT s
+            FROM Start:s-(Friend:e)-:t
+            WHERE s.@cid == t.@cid
+            ACCUM @@modularity += e.weight - s.@weight * t.@weight / (@@totalWeight);
+
+        @@modularity = @@modularity / @@totalWeight;                      
+        PRINT iteration AS Phase1Iter, @@modularity;
+        log(debug > 0, "[redrain]#move", iteration, @@modularity);
+        
+# Phase 1 -- Move
 # For each vertex, calculate the change in modularity FROM adding it to each of the nearby clusters
 # Add vertex to cluster with highest positive change in modularity
 # Repeat the above until no vertices change cluster anymore
-        WHILE @@changed == true DO
-                @@changed = false;
-                Start = SELECT s 
-                        FROM Start:s -(Coworker:e)-> :t
-                        ACCUM s.@clusterEdgeCnt += (t.@cluster->1),
-                                // if this is an incident edge
-                              IF s.@cluster != t.@cluster THEN
-                                      @@edgeCntIncidentCluster += (s.@cluster->1)
-                              ELSE
-                                      @@edgeCntWithinCluster += (s.@cluster->1)
-                              END
-                        POST-ACCUM
-                                INT resultCluster = s.@cluster,
-                                INT m = @@totalNumEdges,
-                                FLOAT maxDeltaQ = -999,
-                                FLOAT deltaQ_new = 0,
-                                FOREACH (cluster, edgeCnt) IN s.@clusterEdgeCnt DO
-                                        INT within = @@edgeCntWithinCluster.get(cluster),
-                                        INT incident = @@edgeCntIncidentCluster.get(cluster),
-                                        deltaQ_new = ((within + s.@clusterEdgeCnt.get(cluster)) / (2.0*m))
-                                                     - pow((incident + s.@edgeCnt)/(2.0*m),2)
-                                                     - (within / (2.0*m)
-                                                     - pow((incident/(2.0*m)),2)
-                                                     - pow((s.@edgeCnt/(2.0*m)),2)),
-                                        IF deltaQ_new > maxDeltaQ AND deltaQ_new > s.@deltaQ AND deltaQ_new > 0 THEN
-                                                maxDeltaQ = deltaQ_new,
-                                                resultCluster = cluster
-                                        END
-                                END,
-                                IF s.@cluster != resultCluster THEN
-                                        s.@cluster = resultCluster,
-                                        s.@deltaQ = maxDeltaQ,
-                                        @@changed += true
-                                END,
-                                s.@clusterEdgeCnt.clear()
-                        ;
-                @@edgeCntWithinCluster.clear();
-                @@edgeCntIncidentCluster.clear();
+        S = SELECT s 
+            FROM Start:s
+            ACCUM @@totIncidentCluster += (s.@cid -> s.@weight); 
+              
+        iteration = 1;
+        Iter1 = iter1 - 1;
+              
+        WHILE (iteration < 2 OR @@modularity - last_modularity > epsilon) LIMIT Iter1 DO
+                iteration += 1;
+                loop = 0;
+                WHILE (loop < partitions) DO 
+                        S = SELECT s 
+                            FROM Start:s -(Friend:e)-> :t
+                            WHERE s.@uid % partitions == loop AND abs(s.@weight - @@totIncidentCluster.get(s.@cid)) > epsilon OR abs(t.@weight - @@totIncidentCluster.get(t.@cid)) > epsilon OR (abs(s.@weight - @@totIncidentCluster.get(s.@cid)) < epsilon AND abs(t.@weight - @@totIncidentCluster.get(t.@cid)) < epsilon AND s.@cid > t.@cid)   # at least one cluster not only itself, or use smaller label
+                            ACCUM s.@weightToCluster += (t.@cid -> e.weight)
+                            POST-ACCUM INT bestCluster = s.@cid,
+                                       FLOAT maxDeltaQ = 0.0,
+                                       FLOAT deltaQ_new = 0.0,
+                                       FOREACH (cluster, weightToC) IN s.@weightToCluster DO   #would be better if this can be distributed
+                                               FLOAT incident = @@totIncidentCluster.get(cluster),
+                                               deltaQ_new = weightToC - 2 * incident * s.@weight/ @@totalWeight,
+                                               IF deltaQ_new > maxDeltaQ OR (abs(deltaQ_new - maxDeltaQ) < epsilon AND cluster < bestCluster) THEN   # when deltaQ_new is equal to maxDeltaQ, and the cluster label is smaller, also change 
+                                                       maxDeltaQ = deltaQ_new,
+                                                       bestCluster = cluster
+                                               END
+                                       END,
+                                       IF s.@cid != bestCluster THEN 
+                                               @@totIncidentCluster += (s.@cid -> (-1 * s.@weight)),
+                                               @@totIncidentCluster += (bestCluster -> s.@weight),
+                                               s.@cid = bestCluster
+                                       END,
+                                       s.@weightToCluster.clear();
+                        loop = loop + 1;
+                END;
+                last_modularity = @@modularity;
+                @@modularity = 0;
+                T1 = SELECT s
+                     FROM Start:s-(Friend:e)-:t
+                     WHERE s.@cid == t.@cid
+                     ACCUM @@modularity += e.weight - s.@weight * t.@weight / (@@totalWeight);
+                @@modularity = @@modularity / @@totalWeight;                      
+                PRINT iteration AS Phase1Iter, @@modularity;
+                log(debug > 0, "[redrain]#move", iteration, @@modularity);
         END;
 
+# Phase 2 --  Merge     
+        iteration2 = 0;
+        WHILE (iteration2 < 2 OR @@modularity2 - last_modularity2 > epsilon) LIMIT iter2 DO
+                iteration2 += 1;
+                Start = SELECT s
+                        FROM Start:s
+                        ACCUM s.@uid = s.@cid;      
+                # Select the vertices with minimal internal id to represent the coarsened graph
+                Start = SELECT s
+                        FROM Start:s 
+                        ACCUM @@representMap += (s.@cid -> s);
+        
+                FOREACH (key, value) IN @@representMap DO
+                        @@representSet += value;                       
+                END;      
+                represent = {@@representSet};
+                @@representMap.clear();
+                @@representSet.clear();
+                log(debug > 0, "[redrain]#2_merge", represent.size()); #@@clusterSizes.size());
+
+            # Get @cweight from totalIncident
+                represent = SELECT s
+                            FROM represent:s
+                            ACCUM s.@cweight = @@totIncidentCluster.get(s.@uid),
+                                  @@clusterSizes += (s.@cid -> 1);
+
+                log(debug > 1, "[redrain]#2_merge", @@weightToClusterMap.size());
+                iteration = 0;
+                last_modularity = 0;
+                @@modularity = 0;
+     
+                WHILE (iteration < 2 OR @@modularity - last_modularity > epsilon) limit iter1 DO
+                        iteration += 1;
+        
+                        # Calculate.weight incident from vertex to cluster in coarsened graph; change every interation
+                        S = SELECT s
+                            FROM Start:s -(Friend:e)-:t
+                            WHERE s.@cid != t.@cid AND @@totIncidentCluster.get(s.@uid) > 0 AND @@totIncidentCluster.get(t.@cid) > 0   #@@totIncidentCluster keeps changing, can be 0
+                            ACCUM @@weightToClusterMap += (s.@uid -> (t.@cid -> e.weight));  # from s, incident to some clusters. Not consider the same cluster
+                        represent = SELECT s 
+                                    FROM represent:s
+                                    POST-ACCUM INT bestCluster = s.@cid,
+                                               FLOAT maxDeltaQ = 0.0,
+                                               FLOAT deltaQ_new = 0.0,
+                                               FOREACH (cluster, weightToC) IN @@weightToClusterMap.get(s.@uid) DO 
+                                                       FLOAT incident = @@totIncidentCluster.get(cluster),
+                                                       IF @@clusterSizes.get(s.@cid) == 1 AND @@clusterSizes.get(cluster) == 1 AND s.@cid < cluster THEN
+                                                               CONTINUE
+                                                       END,
+                                                       deltaQ_new = weightToC - 2 * incident * s.@cweight/ @@totalWeight, #total weight should be the same
+                                                       IF deltaQ_new > maxDeltaQ OR abs(deltaQ_new - maxDeltaQ) < epsilon AND cluster < bestCluster THEN      # new cluster is smaller then the current best cluster
+                                                               maxDeltaQ = deltaQ_new,
+                                                               bestCluster = cluster
+                                                       END
+                                               END,
+                                               IF s.@cid != bestCluster THEN
+                                                       @@totIncidentCluster += (s.@cid -> (-1 * s.@cweight)),
+                                                       @@totIncidentCluster += (bestCluster -> s.@cweight),
+                                                       @@moveComm += (s.@uid -> bestCluster),
+                                                       @@clusterSizes += (s.@cid -> -1),
+                                                       @@clusterSizes += (bestCluster -> 1),
+                                                       s.@cid = bestCluster
+                                               END;
+                        log(debug > 1, "[redrain]#2_merge", @@weightToClusterMap.size()); 
+                        @@weightToClusterMap.clear();
+                   
+                        log(debug > 1, "[redrain]#2_move:", @@moveComm.size());
+                        # move nodes
+                        S = SELECT s
+                            FROM Start:s
+                            WHERE @@moveComm.containsKey(s.@uid)
+                            POST-ACCUM FOREACH v IN @@moveComm.get(s.@uid) DO
+                                               s.@cid = v
+                                       END;
+                        @@moveComm.clear();
+    
+                        last_modularity = @@modularity;           
+                        @@modularity = 0;
+                
+                        S = SELECT s
+                            FROM Start:s-(Friend:e)-:t
+                            WHERE s.@cid == t.@cid
+                            ACCUM @@modularity += e.weight - s.@weight * t.@weight / (@@totalWeight);
+                            @@modularity = @@modularity / @@totalWeight;
+                            PRINT iteration AS Phase1Iter, @@modularity;
+                        log(debug > 0, "[redrain]#2_move", iteration, @@modularity);
+                END;
+        
+                S = SELECT s
+                    FROM represent:s
+                    ACCUM s.@cweight = 0;
+                @@clusterSizes.clear();
+        
+                last_modularity2 = @@modularity2;
+                @@modularity2 = @@modularity;
+                PRINT iteration2 AS Phase2Iter, @@modularity2;
+                log(debug > 0, "[redrain]#2_merge", iteration2, @@modularity2);
+                                      
+        END;
+        
+        
+# Phase 3 -- Refinement
+        iteration = 0;
+        @@modularity = 0;
+        WHILE (iteration < 2 OR @@modularity - last_modularity > epsilon) LIMIT iter3 DO
+                iteration += 1;
+                S = SELECT s 
+                    FROM Start:s -(Friend:e)-> :t
+                    WHERE abs(s.@weight - @@totIncidentCluster.get(s.@cid)) > epsilon OR abs(t.@weight - @@totIncidentCluster.get(t.@cid)) > epsilon OR (abs(s.@weight - @@totIncidentCluster.get(s.@cid)) < epsilon AND abs(t.@weight - @@totIncidentCluster.get(t.@cid)) < epsilon AND s.@cid > t.@cid)   # at least one cluster not only itself, or use smaller label
+                    ACCUM s.@weightToCluster += (t.@cid -> e.weight)
+                    POST-ACCUM
+                            INT bestCluster = s.@cid,
+                            FLOAT maxDeltaQ = 0.0,
+                            FLOAT deltaQ_new = 0.0,
+                            FOREACH (cluster, weightToC) IN s.@weightToCluster DO   #would be better if this can be distributed
+                                    FLOAT incident = @@totIncidentCluster.get(cluster),
+                                    deltaQ_new = weightToC - 2 * incident * s.@weight/ @@totalWeight,
+                                    IF deltaQ_new > maxDeltaQ OR (abs(deltaQ_new - maxDeltaQ) < epsilon AND cluster < bestCluster) THEN   # when deltaQ_new is equal to maxDeltaQ, and the cluster label is smaller, also change 
+                                            maxDeltaQ = deltaQ_new,
+                                            bestCluster = cluster
+                                    END
+                            END,
+                            IF s.@cid != bestCluster THEN 
+                                    @@totIncidentCluster += (s.@cid -> (-1 * s.@weight)),
+                                    @@totIncidentCluster += (bestCluster -> s.@weight),
+                                    s.@cid = bestCluster
+                            END,
+                            s.@weightToCluster.clear();
+
+                last_modularity = @@modularity;
+                @@modularity = 0;
+                T1 = SELECT s
+                     FROM Start:s-(Friend:e)-:t
+                     WHERE s.@cid == t.@cid
+                     ACCUM @@modularity += e.weight - s.@weight * t.@weight / (@@totalWeight);
+                @@modularity = @@modularity / @@totalWeight;                      
+                PRINT iteration AS Phase3Iter, @@modularity;
+                log(debug > 0, "[redrain]#refine", iteration, @@modularity);
+        END;
+        
+                
         Start = {ANY};
+        Start = SELECT s FROM Start:s
+                POST-ACCUM @@clusterSizes += (s.@cid -> 1)
+                           , s.cid = s.@cid
+                           ;
 
-        Start = SELECT s FROM Start:s 
-                POST-ACCUM s.score = s.@cluster;
 
-
+        IF distribution ==0 THEN
+                FOREACH (cluster, csize) IN @@clusterSizes DO
+                        @@clusterMap += (csize -> 1);
+                END;
+                FOREACH (csize, number) IN @@clusterMap DO
+                        @@clusterDist += ClusterNum(csize, number);
+                END;
+                PRINT @@clusterDist;
+        ELSE
+                FOREACH (cluster, csize) IN @@clusterSizes DO
+                        @@clusterMembers += (csize -> cluster);
+                END;
+                PRINT @@clusterMembers;
+        END;
 }
-
-#INSTALL QUERY louvain_attr

--- a/graph_algorithms/algorithms/examples/louvain_file.gsql
+++ b/graph_algorithms/algorithms/examples/louvain_file.gsql
@@ -1,79 +1,300 @@
-      CREATE QUERY louvain_file (FILE f) FOR GRAPH social {
-# Louvain Modularity Method for Community Detection
+      CREATE QUERY louvain_file(INT iter1 = 10, INT iter2 = 10, INT iter3 = 10, INT split = 10, INT distribution = 0, INT debug = 2, FILE f_comm, FILE f_dist) FOR GRAPH social {
+ /*
+ * Parallel Louvain Method with Refinement
+ * https://arxiv.org/pdf/1304.4453
+ * The minimum label heuristics are implemented: https://doi.org/10.1016/j.parco.2015.03.003
+ 
+ * iter: There are three phases in the algorithm -- move, merge and refine. Their max number of iterations are set by iter1, iter2, iter3 respectively.
+ * split: To save memory, split number is 10 by default. When the split number is larger, the query is closer to sequential Louvain Method, which is slower. When the split number is 1, the query is parallel, but requires more memory. 
+ * distribution: 0, only list number; 1, also list members
+ * debug: 0, no modularity info; 1, show debug log; 2, modularity for each iteration
+ * f_comm, f_dist: files to store community label and community distribution
+*/
+        
+        TYPEDEF TUPLE <INT csize, INT number> ClusterNum;
+        TYPEDEF TUPLE <VERTEX node, INT cid, FLOAT deltaQ> vDeltaQ;
+        HeapAccum<vDeltaQ>(1, deltaQ DESC, cid ASC) @largestDeltaQ;   # if deltaQ is the same, select the one with mininal vid 
+        MapAccum<INT, FLOAT> @@totIncidentCluster;   # sun of weight incident to clusters
+        MapAccum<INT, INT> @@clusterSizes;                # size of a cluster
+        MapAccum<INT, FLOAT> @weightToCluster;  # weight from one vertex incident to that cluster
+        SumAccum<FLOAT> @@totalWeight;   # total weight of all edges
+        SumAccum<FLOAT> @weight;          # total weight incident to this vertex
+        SumAccum<FLOAT> @cweight;       # total weight incident to this aggregate vertex
+        SumAccum<INT> @uid;        # which vertex it belongs to
+        SumAccum<INT> @cid;        # which cluster it belongs to
+        SumAccum<INT> @vid;        # internal id
+        SumAccum<FLOAT> @deltaQ;         # contribution to the modularity
+        SumAccum<FLOAT> @@modularity;
+        SumAccum<FLOAT> @@modularity2;
+        MapAccum<INT, MapAccum<INT, FLOAT>> @@weightToClusterMap;   # calculate edges between communities 
+        MapAccum<INT, SetAccum<INT>> @@moveComm; # map of communities that changed its community id
+        MapAccum<INT, MinAccum<VERTEX>> @@representMap;
+        SetAccum<VERTEX> @@representSet;
+        MapAccum<INT, FLOAT> @@vertexMap;
+        MapAccum<INT, MapAccum<INT, FLOAT>> @@edgeMap;
+        HeapAccum<ClusterNum>(100, csize ASC) @@clusterDist;
+        MapAccum<INT, INT> @@clusterMap;
+        MapAccum<INT, ListAccum<INT>> @@clusterMembers;
+        FLOAT last_modularity = 0;
+        FLOAT last_modularity2 = 0;
+        INT iteration;
+        INT Iter1; 
+        FLOAT epsilon = 0.0001;
+        INT iteration2;
+        INT partitions;
+        INT loop;
 
-        # map: <cluster ID, value>
-        MapAccum<int, int> @@edgeCntWithinCluster;     # edge count inside clusters
-        MapAccum<int, int> @@edgeCntIncidentCluster;   # edge count incident to clusters
-        MapAccum<int, int> @@compSizes;                # size of a cluster
-        MapAccum<int, int> @clusterEdgeCnt;  # edge count incident to that cluster
-
-        SumAccum<int> @@totalNumEdges;   # total number of edges
-        SumAccum<int> @edgeCnt;          # total edge count of vertex
-        SumAccum<int> @cluster;        # which cluster it belongs to
-        SumAccum<float> @deltaQ;         # contribution to the modularity
-
-        OrAccum @@changed;               # true if cluster membership changed in this iterator
-  
-        Start = {ANY};
-
+        partitions = split;
+        CASE WHEN split < 1 THEN
+                partitions = 1;
+        END;
+        
 # Initialize: count edges and set a unique cluster ID for each vertex
-        Start = SELECT s 
-                FROM Start:s -(Coworker:e)-> :t
-                ACCUM @@totalNumEdges += 1,
-                      s.@edgeCnt += 1
-                POST-ACCUM s.@cluster = getvid(s); # Label each vertex with its own internal ID
-        @@changed = true;
+        Start = {Person.*};
+        S = SELECT s 
+            FROM Start:s -(Friend:e)-> :t
+            ACCUM @@totalWeight += e.weight,
+                  s.@weight += e.weight
+            POST-ACCUM s.@vid = getvid(s),
+                       s.@uid = s.@vid,
+                       s.@cid = s.@vid;  # Label each vertex with its own internal ID
 
+# Special first iteration of Phase 1
+        iteration = 1;
+        S = SELECT s 
+            FROM Start:s -(Friend:e)-> :t
+            #WHERE s.@cid != t.@cid  # since the default bestCluster is itself, don't need to calculate itself        
+            WHERE s.@cid > t.@cid
+            ACCUM s.@largestDeltaQ += vDeltaQ(t, t.@cid, e.weight - 2 * s.@weight * s.@weight/ @@totalWeight) # weightToCluster is just e.weight
+            POST-ACCUM INT bestCluster = s.@largestDeltaQ.top().cid,
+                       IF s.@largestDeltaQ.size() > 0 and s.@largestDeltaQ.top().deltaQ > 0 and s.@cid != bestCluster THEN 
+                               s.@cid = bestCluster
+                       END,
+                       s.@largestDeltaQ.clear();
+        
+        S = SELECT s
+            FROM Start:s-(Friend:e)-:t
+            WHERE s.@cid == t.@cid
+            ACCUM @@modularity += e.weight - s.@weight * t.@weight / (@@totalWeight);
+
+        @@modularity = @@modularity / @@totalWeight;                      
+        PRINT iteration AS Phase1Iter, @@modularity;
+        log(debug > 0, "[redrain]#move", iteration, @@modularity);
+        
+# Phase 1 -- Move
 # For each vertex, calculate the change in modularity FROM adding it to each of the nearby clusters
 # Add vertex to cluster with highest positive change in modularity
 # Repeat the above until no vertices change cluster anymore
-        WHILE @@changed == true DO
-                @@changed = false;
-                Start = SELECT s 
-                        FROM Start:s -(Coworker:e)-> :t
-                        ACCUM s.@clusterEdgeCnt += (t.@cluster->1),
-                                // if this is an incident edge
-                              IF s.@cluster != t.@cluster THEN
-                                      @@edgeCntIncidentCluster += (s.@cluster->1)
-                              ELSE
-                                      @@edgeCntWithinCluster += (s.@cluster->1)
-                              END
-                        POST-ACCUM
-                                INT resultCluster = s.@cluster,
-                                INT m = @@totalNumEdges,
-                                FLOAT maxDeltaQ = -999,
-                                FLOAT deltaQ_new = 0,
-                                FOREACH (cluster, edgeCnt) IN s.@clusterEdgeCnt DO
-                                        INT within = @@edgeCntWithinCluster.get(cluster),
-                                        INT incident = @@edgeCntIncidentCluster.get(cluster),
-                                        deltaQ_new = ((within + s.@clusterEdgeCnt.get(cluster)) / (2.0*m))
-                                                     - pow((incident + s.@edgeCnt)/(2.0*m),2)
-                                                     - (within / (2.0*m)
-                                                     - pow((incident/(2.0*m)),2)
-                                                     - pow((s.@edgeCnt/(2.0*m)),2)),
-                                        IF deltaQ_new > maxDeltaQ AND deltaQ_new > s.@deltaQ AND deltaQ_new > 0 THEN
-                                                maxDeltaQ = deltaQ_new,
-                                                resultCluster = cluster
-                                        END
-                                END,
-                                IF s.@cluster != resultCluster THEN
-                                        s.@cluster = resultCluster,
-                                        s.@deltaQ = maxDeltaQ,
-                                        @@changed += true
-                                END,
-                                s.@clusterEdgeCnt.clear()
-                        ;
-                @@edgeCntWithinCluster.clear();
-                @@edgeCntIncidentCluster.clear();
+        S = SELECT s 
+            FROM Start:s
+            ACCUM @@totIncidentCluster += (s.@cid -> s.@weight); 
+              
+        iteration = 1;
+        Iter1 = iter1 - 1;
+              
+        WHILE (iteration < 2 OR @@modularity - last_modularity > epsilon) LIMIT Iter1 DO
+                iteration += 1;
+                loop = 0;
+                WHILE (loop < partitions) DO 
+                        S = SELECT s 
+                            FROM Start:s -(Friend:e)-> :t
+                            WHERE s.@uid % partitions == loop AND abs(s.@weight - @@totIncidentCluster.get(s.@cid)) > epsilon OR abs(t.@weight - @@totIncidentCluster.get(t.@cid)) > epsilon OR (abs(s.@weight - @@totIncidentCluster.get(s.@cid)) < epsilon AND abs(t.@weight - @@totIncidentCluster.get(t.@cid)) < epsilon AND s.@cid > t.@cid)   # at least one cluster not only itself, or use smaller label
+                            ACCUM s.@weightToCluster += (t.@cid -> e.weight)
+                            POST-ACCUM INT bestCluster = s.@cid,
+                                       FLOAT maxDeltaQ = 0.0,
+                                       FLOAT deltaQ_new = 0.0,
+                                       FOREACH (cluster, weightToC) IN s.@weightToCluster DO   #would be better if this can be distributed
+                                               FLOAT incident = @@totIncidentCluster.get(cluster),
+                                               deltaQ_new = weightToC - 2 * incident * s.@weight/ @@totalWeight,
+                                               IF deltaQ_new > maxDeltaQ OR (abs(deltaQ_new - maxDeltaQ) < epsilon AND cluster < bestCluster) THEN   # when deltaQ_new is equal to maxDeltaQ, and the cluster label is smaller, also change 
+                                                       maxDeltaQ = deltaQ_new,
+                                                       bestCluster = cluster
+                                               END
+                                       END,
+                                       IF s.@cid != bestCluster THEN 
+                                               @@totIncidentCluster += (s.@cid -> (-1 * s.@weight)),
+                                               @@totIncidentCluster += (bestCluster -> s.@weight),
+                                               s.@cid = bestCluster
+                                       END,
+                                       s.@weightToCluster.clear();
+                        loop = loop + 1;
+                END;
+                last_modularity = @@modularity;
+                @@modularity = 0;
+                T1 = SELECT s
+                     FROM Start:s-(Friend:e)-:t
+                     WHERE s.@cid == t.@cid
+                     ACCUM @@modularity += e.weight - s.@weight * t.@weight / (@@totalWeight);
+                @@modularity = @@modularity / @@totalWeight;                      
+                PRINT iteration AS Phase1Iter, @@modularity;
+                log(debug > 0, "[redrain]#move", iteration, @@modularity);
         END;
 
+# Phase 2 --  Merge     
+        iteration2 = 0;
+        WHILE (iteration2 < 2 OR @@modularity2 - last_modularity2 > epsilon) LIMIT iter2 DO
+                iteration2 += 1;
+                Start = SELECT s
+                        FROM Start:s
+                        ACCUM s.@uid = s.@cid;      
+                # Select the vertices with minimal internal id to represent the coarsened graph
+                Start = SELECT s
+                        FROM Start:s 
+                        ACCUM @@representMap += (s.@cid -> s);
+        
+                FOREACH (key, value) IN @@representMap DO
+                        @@representSet += value;                       
+                END;      
+                represent = {@@representSet};
+                @@representMap.clear();
+                @@representSet.clear();
+                log(debug > 0, "[redrain]#2_merge", represent.size()); #@@clusterSizes.size());
+
+            # Get @cweight from totalIncident
+                represent = SELECT s
+                            FROM represent:s
+                            ACCUM s.@cweight = @@totIncidentCluster.get(s.@uid),
+                                  @@clusterSizes += (s.@cid -> 1);
+
+                log(debug > 1, "[redrain]#2_merge", @@weightToClusterMap.size());
+                iteration = 0;
+                last_modularity = 0;
+                @@modularity = 0;
+     
+                WHILE (iteration < 2 OR @@modularity - last_modularity > epsilon) limit iter1 DO
+                        iteration += 1;
+        
+                        # Calculate.weight incident from vertex to cluster in coarsened graph; change every interation
+                        S = SELECT s
+                            FROM Start:s -(Friend:e)-:t
+                            WHERE s.@cid != t.@cid AND @@totIncidentCluster.get(s.@uid) > 0 AND @@totIncidentCluster.get(t.@cid) > 0   #@@totIncidentCluster keeps changing, can be 0
+                            ACCUM @@weightToClusterMap += (s.@uid -> (t.@cid -> e.weight));  # from s, incident to some clusters. Not consider the same cluster
+                        represent = SELECT s 
+                                    FROM represent:s
+                                    POST-ACCUM INT bestCluster = s.@cid,
+                                               FLOAT maxDeltaQ = 0.0,
+                                               FLOAT deltaQ_new = 0.0,
+                                               FOREACH (cluster, weightToC) IN @@weightToClusterMap.get(s.@uid) DO 
+                                                       FLOAT incident = @@totIncidentCluster.get(cluster),
+                                                       IF @@clusterSizes.get(s.@cid) == 1 AND @@clusterSizes.get(cluster) == 1 AND s.@cid < cluster THEN
+                                                               CONTINUE
+                                                       END,
+                                                       deltaQ_new = weightToC - 2 * incident * s.@cweight/ @@totalWeight, #total weight should be the same
+                                                       IF deltaQ_new > maxDeltaQ OR abs(deltaQ_new - maxDeltaQ) < epsilon AND cluster < bestCluster THEN      # new cluster is smaller then the current best cluster
+                                                               maxDeltaQ = deltaQ_new,
+                                                               bestCluster = cluster
+                                                       END
+                                               END,
+                                               IF s.@cid != bestCluster THEN
+                                                       @@totIncidentCluster += (s.@cid -> (-1 * s.@cweight)),
+                                                       @@totIncidentCluster += (bestCluster -> s.@cweight),
+                                                       @@moveComm += (s.@uid -> bestCluster),
+                                                       @@clusterSizes += (s.@cid -> -1),
+                                                       @@clusterSizes += (bestCluster -> 1),
+                                                       s.@cid = bestCluster
+                                               END;
+                        log(debug > 1, "[redrain]#2_merge", @@weightToClusterMap.size()); 
+                        @@weightToClusterMap.clear();
+                   
+                        log(debug > 1, "[redrain]#2_move:", @@moveComm.size());
+                        # move nodes
+                        S = SELECT s
+                            FROM Start:s
+                            WHERE @@moveComm.containsKey(s.@uid)
+                            POST-ACCUM FOREACH v IN @@moveComm.get(s.@uid) DO
+                                               s.@cid = v
+                                       END;
+                        @@moveComm.clear();
+    
+                        last_modularity = @@modularity;           
+                        @@modularity = 0;
+                
+                        S = SELECT s
+                            FROM Start:s-(Friend:e)-:t
+                            WHERE s.@cid == t.@cid
+                            ACCUM @@modularity += e.weight - s.@weight * t.@weight / (@@totalWeight);
+                            @@modularity = @@modularity / @@totalWeight;
+                            PRINT iteration AS Phase1Iter, @@modularity;
+                        log(debug > 0, "[redrain]#2_move", iteration, @@modularity);
+                END;
+        
+                S = SELECT s
+                    FROM represent:s
+                    ACCUM s.@cweight = 0;
+                @@clusterSizes.clear();
+        
+                last_modularity2 = @@modularity2;
+                @@modularity2 = @@modularity;
+                PRINT iteration2 AS Phase2Iter, @@modularity2;
+                log(debug > 0, "[redrain]#2_merge", iteration2, @@modularity2);
+                                      
+        END;
+        
+        
+# Phase 3 -- Refinement
+        iteration = 0;
+        @@modularity = 0;
+        WHILE (iteration < 2 OR @@modularity - last_modularity > epsilon) LIMIT iter3 DO
+                iteration += 1;
+                S = SELECT s 
+                    FROM Start:s -(Friend:e)-> :t
+                    WHERE abs(s.@weight - @@totIncidentCluster.get(s.@cid)) > epsilon OR abs(t.@weight - @@totIncidentCluster.get(t.@cid)) > epsilon OR (abs(s.@weight - @@totIncidentCluster.get(s.@cid)) < epsilon AND abs(t.@weight - @@totIncidentCluster.get(t.@cid)) < epsilon AND s.@cid > t.@cid)   # at least one cluster not only itself, or use smaller label
+                    ACCUM s.@weightToCluster += (t.@cid -> e.weight)
+                    POST-ACCUM
+                            INT bestCluster = s.@cid,
+                            FLOAT maxDeltaQ = 0.0,
+                            FLOAT deltaQ_new = 0.0,
+                            FOREACH (cluster, weightToC) IN s.@weightToCluster DO   #would be better if this can be distributed
+                                    FLOAT incident = @@totIncidentCluster.get(cluster),
+                                    deltaQ_new = weightToC - 2 * incident * s.@weight/ @@totalWeight,
+                                    IF deltaQ_new > maxDeltaQ OR (abs(deltaQ_new - maxDeltaQ) < epsilon AND cluster < bestCluster) THEN   # when deltaQ_new is equal to maxDeltaQ, and the cluster label is smaller, also change 
+                                            maxDeltaQ = deltaQ_new,
+                                            bestCluster = cluster
+                                    END
+                            END,
+                            IF s.@cid != bestCluster THEN 
+                                    @@totIncidentCluster += (s.@cid -> (-1 * s.@weight)),
+                                    @@totIncidentCluster += (bestCluster -> s.@weight),
+                                    s.@cid = bestCluster
+                            END,
+                            s.@weightToCluster.clear();
+
+                last_modularity = @@modularity;
+                @@modularity = 0;
+                T1 = SELECT s
+                     FROM Start:s-(Friend:e)-:t
+                     WHERE s.@cid == t.@cid
+                     ACCUM @@modularity += e.weight - s.@weight * t.@weight / (@@totalWeight);
+                @@modularity = @@modularity / @@totalWeight;                      
+                PRINT iteration AS Phase3Iter, @@modularity;
+                log(debug > 0, "[redrain]#refine", iteration, @@modularity);
+        END;
+        
+                
+        f_comm.println("Vertex_ID", "community_id");
         Start = {ANY};
-
-
-
-        f.println("Vertex_ID", "Cluster_ID");
         Start = SELECT s FROM Start:s
-                POST-ACCUM f.println(s, s.@cluster);
-}
+                POST-ACCUM @@clusterSizes += (s.@cid -> 1)
+                           , f_comm.println(s, s.@cid)
+                           ;
 
-#INSTALL QUERY louvain_file
+
+        IF distribution ==0 THEN
+                FOREACH (cluster, csize) IN @@clusterSizes DO
+                        @@clusterMap += (csize -> 1);
+                END;
+                FOREACH (csize, number) IN @@clusterMap DO
+                        @@clusterDist += ClusterNum(csize, number);
+                END;
+                FOREACH item IN @@clusterDist DO
+                        f_dist.println(item.csize, item.number);
+                END;
+        ELSE
+                FOREACH (cluster, csize) IN @@clusterSizes DO
+                        @@clusterMembers += (csize -> cluster);
+                END;
+                FOREACH (key, value) IN @@clusterMembers DO
+                        f_dist.println(key, value);
+                END;
+        END;
+}

--- a/graph_algorithms/algorithms/examples/mst.gsql
+++ b/graph_algorithms/algorithms/examples/mst.gsql
@@ -1,0 +1,37 @@
+CREATE QUERY mst (VERTEX source) FOR GRAPH social {
+/* Minimal Spanning Tree (MST)
+Given an undirected graph, and a source vertex, print out a MST for the connected subgraph which contains the source vertex.
+1. Start with a set A = {source vertex}
+2. For all vertices in A, find another vertex y in the graph but not A which is connected to a vertex x in A such that the weight on the edge e(x,y) is the smallest among all such edges from a vertex in A to a vertex not in A. Add y to A, and add the edge (x,y) to MST
+3. Repeat 2 until A has no edge linking to any other vertex in the graph.
+The ACCM version shows display by default.  
+*/
+        TYPEDEF TUPLE<VERTEX toV, EDGE their_edge, FLOAT weight> EDGE_WEIGHT;
+        HeapAccum<EDGE_WEIGHT>(1, weight ASC) @@chosen_edge; //only need to keep the minimal tuple
+        SetAccum<EDGE> @@mst;
+        OrAccum @chosen;
+
+        A = {source};
+        // initialize the source vertex
+        Current = SELECT a
+                  FROM A:a
+                  ACCUM a.@chosen = true;
+
+        WHILE (Current.size() > 0) DO
+                Current = SELECT t
+                          FROM A:s -((Friend|PI|II):e) -> :t
+                          WHERE t.@chosen == false    // vertex not in A
+                          ACCUM @@chosen_edge += EDGE_WEIGHT(t, e, e.weight)
+                          POST-ACCUM IF t == @@chosen_edge.top().toV THEN    
+                                              t.@chosen = TRUE      // mark the chosen vertex to add into A
+                                     END
+                          HAVING t.@chosen' == false and t.@chosen == true;
+                IF @@chosen_edge.size() > 0 THEN
+                        @@mst += @@chosen_edge.top().their_edge;
+                END;    
+                @@chosen_edge.clear();
+                A = A UNION Current;      // update A
+        END;
+
+        PRINT @@mst;
+}

--- a/graph_algorithms/algorithms/examples/mst_attr.gsql
+++ b/graph_algorithms/algorithms/examples/mst_attr.gsql
@@ -1,0 +1,38 @@
+CREATE QUERY mst_attr (VERTEX source) FOR GRAPH social {
+/* Minimal Spanning Tree (MST)
+Given an undirected graph, and a source vertex, print out a MST for the connected subgraph which contains the source vertex.
+1. Start with a set A = {source vertex}
+2. For all vertices in A, find another vertex y in the graph but not A which is connected to a vertex x in A such that the weight on the edge e(x,y) is the smallest among all such edges from a vertex in A to a vertex not in A. Add y to A, and add the edge (x,y) to MST
+3. Repeat 2 until A has no edge linking to any other vertex in the graph.
+The ACCM version shows display by default.  
+*/
+        TYPEDEF TUPLE<VERTEX fromV, VERTEX toV, FLOAT weight> EDGE_WEIGHT;
+        HeapAccum<EDGE_WEIGHT>(1, weight ASC) @@chosen_edge; //only need to keep the minimal tuple
+        OrAccum @chosen;
+
+        A = {source};
+        // initialize the source vertex
+        Current = SELECT a
+                  FROM A:a
+                  ACCUM a.@chosen = true;
+
+        WHILE (Current.size() > 0) DO
+                Current = SELECT t
+                          FROM A:s -((Friend|PI|II):e) -> :t
+                          WHERE t.@chosen == false    // vertex not in A
+                          ACCUM @@chosen_edge += EDGE_WEIGHT(s, t, e.weight)
+                          POST-ACCUM IF t == @@chosen_edge.top().toV THEN    
+                                              t.@chosen = TRUE      // mark the chosen vertex to add into A
+                                     END
+                          HAVING t.@chosen' == false and t.@chosen == true;
+                IF @@chosen_edge.size() > 0 THEN
+                        S = SELECT s
+                            FROM Current:s -((Friend|PI|II):e) -> :t
+                            WHERE t == @@chosen_edge.top().fromV
+                            ACCUM e.in_mst = TRUE;
+                END;    
+                @@chosen_edge.clear();
+                A = A UNION Current;      // update A
+        END;
+
+}

--- a/graph_algorithms/algorithms/examples/mst_file.gsql
+++ b/graph_algorithms/algorithms/examples/mst_file.gsql
@@ -1,0 +1,40 @@
+      CREATE QUERY mst_file (VERTEX source, FILE f) FOR GRAPH social {
+/* Minimal Spanning Tree (MST)
+Given an undirected graph, and a source vertex, print out a MST for the connected subgraph which contains the source vertex.
+1. Start with a set A = {source vertex}
+2. For all vertices in A, find another vertex y in the graph but not A which is connected to a vertex x in A such that the weight on the edge e(x,y) is the smallest among all such edges from a vertex in A to a vertex not in A. Add y to A, and add the edge (x,y) to MST
+3. Repeat 2 until A has no edge linking to any other vertex in the graph.
+The ACCM version shows display by default.  
+*/
+        TYPEDEF TUPLE<VERTEX fromV, VERTEX toV, FLOAT weight> EDGE_WEIGHT;
+        HeapAccum<EDGE_WEIGHT>(1, weight ASC) @@chosen_edge; //only need to keep the minimal tuple
+        SetAccum<EDGE_WEIGHT> @@mst;
+        OrAccum @chosen;
+
+        A = {source};
+        // initialize the source vertex
+        Current = SELECT a
+                  FROM A:a
+                  ACCUM a.@chosen = true;
+
+        WHILE (Current.size() > 0) DO
+                Current = SELECT t
+                          FROM A:s -((Friend|PI|II):e) -> :t
+                          WHERE t.@chosen == false    // vertex not in A
+                          ACCUM @@chosen_edge += EDGE_WEIGHT(s, t, e.weight)
+                          POST-ACCUM IF t == @@chosen_edge.top().toV THEN    
+                                              t.@chosen = TRUE      // mark the chosen vertex to add into A
+                                     END
+                          HAVING t.@chosen' == false and t.@chosen == true;
+                IF @@chosen_edge.size() > 0 THEN
+                        @@mst += @@chosen_edge.top();
+                END;    
+                @@chosen_edge.clear();
+                A = A UNION Current;      // update A
+        END;
+
+        f.println("From", "To", "Weight");
+        FOREACH e IN @@mst DO 
+            f.println(e.fromV, e.toV, e.weight);
+        END;
+}

--- a/graph_algorithms/algorithms/install.sh
+++ b/graph_algorithms/algorithms/install.sh
@@ -55,7 +55,7 @@ while [ !$finished ]; do
 				break;;
 			"Community detection: Louvain" )
 				algoName="louvain"
-				echo "  louvain() works on undirected edges"
+				echo "  louvain() works on undirected weighted edges"
 				break;;
 			"PageRank" )
 				algoName="pageRank"
@@ -207,7 +207,7 @@ while [ !$finished ]; do
 
 
      	# 5. Ask for edge weight name. Replace *edge-weight* placeholder.
-	if [ "${algoName}" == "shortest_ss_pos_wt" ] || [ "${algoName}" == "shortest_ss_any_wt" ] || [ "${algoName}" == "pageRank_wt" ] || [ "${algoName}" == "mst" ]; then
+	if [ "${algoName}" == "shortest_ss_pos_wt" ] || [ "${algoName}" == "shortest_ss_any_wt" ] || [ "${algoName}" == "pageRank_wt" ] || [ "${algoName}" == "mst" ] || [ "${algoName}" == "louvain" ]; then
 		while true; do
                 	read -p "Edge attribute that stores FLOAT weight:"  weight
 			if [[ $(countEdgeAttr $weight) > 0 ]]; then

--- a/graph_algorithms/algorithms/install.sh
+++ b/graph_algorithms/algorithms/install.sh
@@ -39,7 +39,7 @@ fi
 finished=false
 while [ !$finished ]; do
 	echo; echo "Please enter the index of the algorithm you want to create or EXIT:"
-	select algo in "EXIT" "Closeness Centrality" "Connected Components" "Label Propagation" "Community detection: Louvain" "PageRank" "Weighted PageRank" "Personalized PageRank" "Shortest Path, Single-Source, No Weight" "Shortest Path, Single-Source, Positive Weight" "Shortest Path, Single-Source, Any Weight" "Triangle Counting(minimal memory)" "Triangle Counting(fast, more memory)" "Cosine Similarity (single vertex)" "Cosine Similary (all vertices)" "Jaccard Similarity (single vertex)" "Jaccard Similary (all vertices)"; do
+	select algo in "EXIT" "Closeness Centrality" "Connected Components" "Label Propagation" "Community detection: Louvain" "PageRank" "Weighted PageRank" "Personalized PageRank" "Shortest Path, Single-Source, No Weight" "Shortest Path, Single-Source, Positive Weight" "Shortest Path, Single-Source, Any Weight" "Minimal Spanning Tree (MST)" "Triangle Counting(minimal memory)" "Triangle Counting(fast, more memory)" "Cosine Similarity (single vertex)" "Cosine Similary (all vertices)" "Jaccard Similarity (single vertex)" "Jaccard Similary (all vertices)"; do
     	case $algo in
 			"Closeness Centrality" )
 				algoName="closeness_cent"
@@ -81,6 +81,10 @@ while [ !$finished ]; do
 				algoName="shortest_ss_any_wt"
 				echo "  shortest_ss_any_wt() works on weighted directed or undirected edges"
 				break;;
+                        "Minimal Spanning Tree (MST)" )
+                                algoName="mst"
+                                echo "  mst() works on weighted undirected edges"
+                                break;;
 			"Triangle Counting(minimal memory)" )
 				algoName="tri_count"
 				echo "  tri_count() works on undirected edges"
@@ -203,7 +207,7 @@ while [ !$finished ]; do
 
 
      	# 5. Ask for edge weight name. Replace *edge-weight* placeholder.
-	if [ "${algoName}" == "shortest_ss_pos_wt" ] || [ "${algoName}" == "shortest_ss_any_wt" ] || [ "${algoName}" == "pageRank_wt" ]; then
+	if [ "${algoName}" == "shortest_ss_pos_wt" ] || [ "${algoName}" == "shortest_ss_any_wt" ] || [ "${algoName}" == "pageRank_wt" ] || [ "${algoName}" == "mst" ]; then
 		while true; do
                 	read -p "Edge attribute that stores FLOAT weight:"  weight
 			if [[ $(countEdgeAttr $weight) > 0 ]]; then
@@ -351,6 +355,19 @@ END
 						fi
 					  done
 					fi
+
+                                        # * eBoolType*
+                                        if [[ $(countStringInFile "\*eBoolAttr\*" $attrQuery) > 0 ]]; then
+                                          while true; do
+                                                read -p "Edge attribute to store BOOL result (e.g. mst): " eBoolAttr
+                                                if [[ $(countEdgeAttr $eBoolAttr) > 0 ]]; then
+                                                        sed -i "s/\*eBoolAttr\*/$eBoolAttr/g" $attrQuery;
+                                                        break;
+                                                else
+                                                        echo " *** Edge attribute name not found. Try again."
+                                                fi
+                                          done
+                                        fi
 					
 					# edge to insert for similarity algorithms
 					if [[ $(countStringInFile "\*insert-edge-name\*" $attrQuery) > 0 ]]; then
@@ -476,6 +493,19 @@ END
                                                         break;
                                                 else
                                                         echo " *** Vertex attribute name not found. Try again."
+                                                fi
+                                          done
+                                        fi
+
+                                        # * eBoolType*
+                                        if [[ $(countStringInFile "\*eBoolAttr\*" $attrQuery) > 0 ]]; then
+                                          while true; do
+                                                read -p "Edge attribute to store BOOL result (e.g. mst): " eBoolAttr
+                                                if [[ $(countEdgeAttr $eBoolAttr) > 0 ]]; then
+                                                        sed -i "s/\*eBoolAttr\*/$eBoolAttr/g" $attrQuery;
+                                                        break;
+                                                else
+                                                        echo " *** Edge attribute name not found. Try again."
                                                 fi
                                           done
                                         fi

--- a/graph_algorithms/algorithms/templates/cosine_nbor_ap.gtmp
+++ b/graph_algorithms/algorithms/templates/cosine_nbor_ap.gtmp
@@ -1,83 +1,59 @@
 *ATTR**SUB* CREATE QUERY cosine_nbor_ap_sub*EXT* (VERTEX<*vertex-types*> source, INT topK) FOR GRAPH *graph* {
-*ACCM**SUB* CREATE QUERY cosine_nbor_ap_sub*EXT* (VERTEX source) FOR GRAPH *graph* RETURNS (MapAccum<VERTEX, FLOAT>){
-*FILE**SUB* CREATE QUERY cosine_nbor_ap_sub*EXT* (VERTEX source) FOR GRAPH *graph* RETURNS (MapAccum<VERTEX, FLOAT>){
+*ACCM**SUB* CREATE QUERY cosine_nbor_ap_sub*EXT* (VERTEX source, INT topK) FOR GRAPH *graph* RETURNS (MapAccum<VERTEX, FLOAT>){
+*FILE**SUB* CREATE QUERY cosine_nbor_ap_sub*EXT* (VERTEX source, INT topK, FILE f) FOR GRAPH *graph*{
 /* This subquery calculates the Cosine Similarity between a given vertex and every other vertex.
 Cosine similarity = A \dot B / ||A|| \dot ||B||
 */
 
-*ACCM*  MapAccum<VERTEX, FLOAT> @@result;
-*FILE*  MapAccum<VERTEX, FLOAT> @@result;
-        SumAccum<FLOAT> @numerator, @@norm1, @norm2;
-*ATTR*  SumAccum<FLOAT> @cosine;
+*ACCM*  MapAccum<VERTEX, FLOAT> @@topK_result;
+        SumAccum<FLOAT> @numerator, @@norm1, @norm2, @similarity;
 
-        start1 = {source};
+        start = {source};
         subjects = SELECT t
-                   FROM start1:s -(*edge-types*:e)-> :t
+                   FROM start:s -(*edge-types*:e)-> :t
                    ACCUM t.@numerator = e.*edge-weight*,
                          @@norm1 += pow(e.*edge-weight*, 2);
 
         neighbours = SELECT t
                      FROM subjects:s -(*sec-edge-types*:e)-> *vertex-types*:t
-                     WHERE t != source and getvid(source) < getvid(t)
+                     WHERE t != source
                      ACCUM t.@numerator += s.@numerator * e.*edge-weight*;
 
         neighbours = SELECT s
                      FROM neighbours:s -(*edge-types*:e)-> :t
                      ACCUM s.@norm2 += pow(e.*edge-weight*, 2)
-*ATTR*               POST-ACCUM s.@cosine = s.@numerator/sqrt(@@norm1 * s.@norm2)
-*ATTR*               ORDER BY s.@cosine DESC
-*ATTR*               LIMIT topK
-*ACCM*               POST-ACCUM @@result += (s -> s.@numerator/sqrt(@@norm1 * s.@norm2))
-*FILE*               POST-ACCUM @@result += (s -> s.@numerator/sqrt(@@norm1 * s.@norm2))
-                 ;
+                     POST-ACCUM s.@similarity = s.@numerator/sqrt(@@norm1 * s.@norm2)
+                     ORDER BY s.@similarity DESC
+                     LIMIT topK;
 *ATTR*  neighbours = SELECT s
 *ATTR*               FROM neighbours:s
-*ATTR*               POST-ACCUM insert into *insert-edge-name* values(source, s, s.@cosine);
-
-*ACCM*  RETURN @@result;
-*FILE*  RETURN @@result;
+*ATTR*               POST-ACCUM insert into *insert-edge-name* values(source, s, s.@similarity);
+*ACCM*  neighbours = SELECT s
+*ACCM*               FROM neighbours:s 
+*ACCM*               ACCUM @@topK_result += (s -> s.@similarity);
+*ACCM*  return @@topK_result;
+*FILE*  neighbours = SELECT s
+*FILE*               FROM neighbours:s
+*FILE*               POST-ACCUM f.println(source, s, s.@similarity);
 }
 
 
 *ATTR*CREATE QUERY cosine_nbor_ap*EXT* (INT topK) FOR GRAPH *graph* { 
 *ACCM*CREATE QUERY cosine_nbor_ap*EXT* (INT topK) FOR GRAPH *graph*{
-*FILE*CREATE QUERY cosine_nbor_ap*EXT* (INT topK, STRING filepath) FOR GRAPH *graph*{
+*FILE*CREATE QUERY cosine_nbor_ap*EXT* (INT topK, FILE f) FOR GRAPH *graph*{
 /* This query calls the subquery cosine_nbor_ap_sub*EXT* to get the similarity score of every pair of vertices.
 1. The JSON and FILE version keeps the top k pairs of vertices. The result in FILE version is not in order.
 2. The Attribute version insert edges between the pairs, with the score as an edge attribute.
    A similarity edge with one FLOAT attribute in the schema is required for this version.
 */
-*ACCM*  TYPEDEF tuple<VERTEX vertex1, VERTEX vertex2, FLOAT score> SIMILARITY_SCORE;
-*FILE*  TYPEDEF tuple<VERTEX vertex1, VERTEX vertex2, FLOAT score> SIMILARITY_SCORE;
-*FILE*  FILE f(filepath);
-*ACCM*  MapAccum<VERTEX, FLOAT> @single_result;
-*FILE*  MapAccum<VERTEX, FLOAT> @single_result;
-*ACCM*  HeapAccum<SIMILARITY_SCORE>(topK, score DESC) @@total_result;
-*FILE*  HeapAccum<SIMILARITY_SCORE>(topK, score DESC) @@total_result;
-
+*ACCM*  MapAccum<VERTEX, FLOAT> @result;
         start = {*vertex-types*.*}; 
+*FILE*  f.println("Vertex1","Vertex2","Similarity");
         start = SELECT s
                 FROM start:s
-*ATTR*          ACCUM cosine_nbor_ap_sub*EXT* (s, topK)
-*ACCM*          ACCUM s.@single_result = cosine_nbor_ap_sub*EXT* (s)
-*FILE*          ACCUM s.@single_result = cosine_nbor_ap_sub*EXT* (s)
-*ACCM*          POST-ACCUM 
-*ACCM*                  FOREACH (key, value) IN s.@single_result DO
-*ACCM*                          @@total_result += SIMILARITY_SCORE(s, key, value)
-*ACCM*                  END
-*FILE*          POST-ACCUM
-*FILE*                  FOREACH (key, value) IN s.@single_result DO
-*FILE*                          @@total_result += SIMILARITY_SCORE(s, key, value)
-*FILE*                  END
-            ;
-        
-*ACCM*  PRINT @@total_result;
-*FILE*  f.println("Vertex1","Vertex2","Similarity");
-*FILE*  FOREACH item IN @@total_result DO
-*FILE*          f.println(item.vertex1, item.vertex2, item.score);
-*FILE*  END;
-
+*ATTR*          ACCUM cosine_nbor_ap_sub_attr(s, topK);
+*ACCM*          ACCUM s.@result = cosine_nbor_ap_sub(s, topK);
+*FILE*          ACCUM cosine_nbor_ap_sub_file(s, topK, f);
+*ACCM*  PRINT start.@result;
 }
 
-#install query cosine_nbor_ap_sub*EXT*
-#install query cosine_nbor_ap*EXT* 

--- a/graph_algorithms/algorithms/templates/cosine_nbor_ss.gtmp
+++ b/graph_algorithms/algorithms/templates/cosine_nbor_ss.gtmp
@@ -1,25 +1,17 @@
 *ATTR*CREATE QUERY cosine_nbor_ss*EXT* (VERTEX<*vertex-types*> source, INT topK) FOR GRAPH *graph* {
 *ACCM*CREATE QUERY cosine_nbor_ss*EXT* (VERTEX source, INT topK) FOR GRAPH *graph* {
-*FILE*CREATE QUERY cosine_nbor_ss*EXT* (VERTEX source, INT topK, STRING filepath) FOR GRAPH *graph* {
+*FILE*CREATE QUERY cosine_nbor_ss*EXT* (VERTEX source, INT topK, FILE f) FOR GRAPH *graph* {
 /* This query calculates the Cosine Similarity between a given vertex and every other vertex.
 Cosine similarity = A \dot B / ||A|| \dot ||B||
 1. The JSON and FILE version keeps the top k pairs of vertices. The result in FILE version is not in order.
 2. The Attribute version insert edges between the pairs, with the score as an edge attribute.
    A similarity edge with one FLOAT attribute in the schema is required for this version.
 */
+        SumAccum<FLOAT> @numerator, @@norm1, @norm2, @similarity;
 
-*FILE*  TYPEDEF tuple<VERTEX vertex1, VERTEX vertex2, FLOAT score> SIMILARITY_SCORE;
-*FILE*  FILE f(filepath);
-*ACCM*  TYPEDEF tuple<VERTEX vertex1, VERTEX vertex2, FLOAT score> SIMILARITY_SCORE;
-
-*FILE*  HeapAccum<SIMILARITY_SCORE>(topK, score DESC) @@result_topK;
-*ACCM*  HeapAccum<SIMILARITY_SCORE>(topK, score DESC) @@result_topK;    
-        SumAccum<FLOAT> @numerator, @@norm1, @norm2;
-*ATTR*  SumAccum<FLOAT> @cosine;
-
-        start1 = {source};
+        start = {source};
         subjects = SELECT t
-                   FROM start1:s -(*edge-types*:e)-> :t
+                   FROM start:s -(*edge-types*:e)-> :t
                    ACCUM t.@numerator = e.*edge-weight*,
                          @@norm1 += pow(e.*edge-weight*, 2);
 
@@ -31,22 +23,20 @@ Cosine similarity = A \dot B / ||A|| \dot ||B||
         neighbours = SELECT s
                      FROM neighbours:s -(*edge-types*:e)-> :t
                      ACCUM s.@norm2 += pow(e.*edge-weight*, 2)
-*ATTR*        	     POST-ACCUM s.@cosine = s.@numerator/sqrt(@@norm1 * s.@norm2)
-*ATTR*               ORDER BY s.@cosine DESC
-*ATTR*               LIMIT topK
-*FILE*               POST-ACCUM @@result_topK += SIMILARITY_SCORE(source, s, s.@numerator/sqrt(@@norm1 * s.@norm2))
-*ACCM*        	     POST-ACCUM @@result_topK += SIMILARITY_SCORE(source, s, s.@numerator/sqrt(@@norm1 * s.@norm2))
-                     ;
+        	     POST-ACCUM s.@similarity = s.@numerator/sqrt(@@norm1 * s.@norm2)
+                     ORDER BY s.@similarity DESC
+                     LIMIT topK;
+
 *ATTR*  neighbours = SELECT s
 *ATTR*               FROM neighbours:s
-*ATTR*               POST-ACCUM insert into *insert-edge-name* values(source, s, s.@cosine);
+*ATTR*               POST-ACCUM insert into *insert-edge-name* values(source, s, s.@similarity);
 
-*ACCM*  PRINT @@result_topK;
+*ACCM*  PRINT neighbours.@similarity;
 
-*FILE*  f.println("Vertex1","Vertex2","Similarity");
-*FILE*  FOREACH item IN @@result_topK DO
-*FILE*           f.println(item.vertex1, item.vertex2, item.score);
-*FILE*  END;
+*FILE*  f.println("Vertex1", "Vertex2", "Similarity");
+*FILE*  neighbours = SELECT s 
+*FILE*               FROM neighbours:s
+*FILE*               POST-ACCUM f.println(source, s, s.@similarity);
 
 }
 

--- a/graph_algorithms/algorithms/templates/jaccard_nbor_ap.gtmp
+++ b/graph_algorithms/algorithms/templates/jaccard_nbor_ap.gtmp
@@ -1,14 +1,13 @@
 *ATTR**SUB* CREATE QUERY jaccard_nbor_ap_sub*EXT* (vertex<*vertex-types*> source, INT topK) FOR GRAPH *graph* {
-*ACCM**SUB* CREATE QUERY jaccard_nbor_ap_sub*EXT* (vertex source) FOR GRAPH *graph* RETURNS (MapAccum<vertex, float>){
-*FILE**SUB* CREATE QUERY jaccard_nbor_ap_sub*EXT* (vertex source) FOR GRAPH *graph* RETURNS (MapAccum<vertex, float>){
+*ACCM**SUB* CREATE QUERY jaccard_nbor_ap_sub*EXT* (vertex source, INT topK) FOR GRAPH *graph* RETURNS (MapAccum<VERTEX, FLOAT>){
+*FILE**SUB* CREATE QUERY jaccard_nbor_ap_sub*EXT* (vertex source, INT topK, FILE f) FOR GRAPH *graph*{
 /* This subquery calculates the Jaccard Similarity between a given vertex and every other vertex.
 Jaccard similarity = intersection_size / (size_A + size_B - intersection_size)
 */
     
-*ACCM*  MapAccum<vertex, float> @@result;
-*FILE*  MapAccum<vertex, float> @@result;
-        SumAccum<int> @intersection_size, @@set_size_A, @set_size_B;
-*ATTR*  SumAccum<FLOAT> @jaccard;
+*ACCM*  MapAccum<VERTEX, FLOAT> @@topK_result;
+        SumAccum<INT> @intersection_size, @@set_size_A, @set_size_B;
+        SumAccum<FLOAT> @similarity;
 
         Start (ANY) = {source};
         Start = SELECT s
@@ -20,61 +19,40 @@ Jaccard similarity = intersection_size / (size_A + size_B - intersection_size)
 
         Others = SELECT t
                  FROM Subjects:s -(*sec-edge-types*:e)- :t
-                 WHERE t != source and getvid(source) < getvid(t)
+                 WHERE t != source 
                  ACCUM t.@intersection_size += 1, 
                        t.@set_size_B = t.outdegree("*edge-types*")
-*ATTR*           POST-ACCUM t.@jaccard = t.@intersection_size*1.0/(@@set_size_A + t.@set_size_B - t.@intersection_size)
-*ATTR*           ORDER BY t.@jaccard DESC
-*ATTR*           LIMIT topK
-*ACCM*           POST-ACCUM @@result += (t -> t.@intersection_size*1.0/(@@set_size_A + t.@set_size_B - t.@intersection_size))
-*FILE*           POST-ACCUM @@result += (t -> t.@intersection_size*1.0/(@@set_size_A + t.@set_size_B - t.@intersection_size))
-                 ;
+                 POST-ACCUM t.@similarity = t.@intersection_size*1.0/(@@set_size_A + t.@set_size_B - t.@intersection_size)
+                 ORDER BY t.@similarity DESC
+                 LIMIT topK;
 *ATTR*  Others = SELECT s
 *ATTR*           FROM Others:s
-*ATTR*           POST-ACCUM insert into *insert-edge-name* values(source, s, s.@jaccard);
-
-*ACCM*  RETURN @@result;
-*FILE*  RETURN @@result;
+*ATTR*           POST-ACCUM insert into *insert-edge-name* values(source, s, s.@similarity);
+*ACCM*  Others = SELECT s
+*ACCM*           FROM Others:s
+*ACCM*           ACCUM @@topK_result += (s -> s.@similarity);
+*ACCM*  return @@topK_result;
+*FILE*  Others = SELECT s
+*FILE*           FROM Others:s
+*FILE*           POST-ACCUM f.println(source, s, s.@similarity);
 }
 
 *ATTR*CREATE QUERY jaccard_nbor_ap*EXT* (INT topK) FOR GRAPH *graph* {
 *ACCM*CREATE QUERY jaccard_nbor_ap*EXT* (INT topK) FOR GRAPH *graph*{
-*FILE*CREATE QUERY jaccard_nbor_ap*EXT* (INT topK, STRING filepath) FOR GRAPH *graph*{
+*FILE*CREATE QUERY jaccard_nbor_ap*EXT* (INT topK, FILE f) FOR GRAPH *graph*{
 /* This query calls the subquery jaccard_nbor_ap_sub*EXT* to get the similarity score of every pair of vertices.
 1. The JSON and FILE version keeps the top k pairs of vertices. The result in FILE version is not in order.
 2. The Attribute version insert edges between the pairs, with the score as an edge attribute. 
    A similarity edge with one float attribute in the schema is required for this version.  
 */
-
-*ACCM*  TYPEDEF tuple<vertex vertex1, vertex vertex2, float score> SIMILARITY_SCORE;
-*FILE*  TYPEDEF tuple<vertex vertex1, vertex vertex2, float score> SIMILARITY_SCORE;
-*FILE*  FILE f(filepath);
-*ACCM*  MapAccum<vertex, float> @single_result;
-*FILE*  MapAccum<vertex, float> @single_result;
-*ACCM*  HeapAccum<SIMILARITY_SCORE>(topK, score DESC) @@total_result;
-*FILE*  HeapAccum<SIMILARITY_SCORE>(topK, score DESC) @@total_result;
-
+*ACCM*  MapAccum<VERTEX, FLOAT> @result;
         start = {*vertex-types*.*};
+*FILE*  f.println("Vertex1","Vertex2","Similarity");
         start = SELECT s
                 FROM start:s
-*ATTR*          ACCUM jaccard_nbor_ap_sub*EXT* (s, topK)
-*ACCM*          ACCUM s.@single_result = jaccard_nbor_ap_sub*EXT* (s)
-*FILE*          ACCUM s.@single_result = jaccard_nbor_ap_sub*EXT* (s)
-*ACCM*          POST-ACCUM
-*ACCM*                  FOREACH (key, value) IN s.@single_result DO
-*ACCM*                          @@total_result += SIMILARITY_SCORE(s, key, value)
-*ACCM*                  END
-*FILE*          POST-ACCUM
-*FILE*                  FOREACH (key, value) IN s.@single_result DO
-*FILE*                          @@total_result += SIMILARITY_SCORE(s, key, value)
-*FILE*                  END
-                ;
-
-*ACCM*  PRINT @@total_result;
-*FILE*  f.println("Vertex1","Vertex2","Similarity");
-*FILE*  FOREACH item IN @@total_result DO
-*FILE*          f.println(item.vertex1, item.vertex2, item.score);
-*FILE*  END;
-
+*ATTR*          ACCUM jaccard_nbor_ap_sub_attr(s, topK);
+*ACCM*          ACCUM s.@result = jaccard_nbor_ap_sub(s, topK);
+*FILE*          ACCUM jaccard_nbor_ap_sub_file(s, topK, f);
+*ACCM*  PRINT start.@result;
 }
 

--- a/graph_algorithms/algorithms/templates/jaccard_nbor_ss.gtmp
+++ b/graph_algorithms/algorithms/templates/jaccard_nbor_ss.gtmp
@@ -1,21 +1,14 @@
 *ATTR*CREATE QUERY jaccard_nbor_ss*EXT* (VERTEX<*vertex-types*> source, INT topK) FOR GRAPH *graph* {
 *ACCM*CREATE QUERY jaccard_nbor_ss*EXT* (VERTEX source, INT topK) FOR GRAPH *graph* {
-*FILE*CREATE QUERY jaccard_nbor_ss*EXT* (VERTEX source, INT topK, STRING filepath) FOR GRAPH *graph* {
+*FILE*CREATE QUERY jaccard_nbor_ss*EXT* (VERTEX source, INT topK, FILE f) FOR GRAPH *graph* {
 /* This query calculates the Jaccard Similarity between a given vertex and every other vertex.
 Jaccard similarity = intersection_size / (size_A + size_B - intersection_size)
 1. The JSON and FILE version keeps the top k pairs of vertices. The result in FILE version is not in order.
 2. The Attribute version insert edges between the pairs, with the score as an edge attribute.
    A similarity edge with one FLOAT attribute in the schema is required for this version.
 */
-
-*FILE*  TYPEDEF tuple<VERTEX vertex1, VERTEX vertex2, FLOAT score> SIMILARITY_SCORE;
-*FILE*  FILE f(filepath);
-*ACCM*  TYPEDEF tuple<VERTEX vertex1, VERTEX vertex2, FLOAT score> SIMILARITY_SCORE;
-
-*FILE*  HeapAccum<SIMILARITY_SCORE>(topK, score DESC) @@result_topK;
-*ACCM*  HeapAccum<SIMILARITY_SCORE>(topK, score DESC) @@result_topK;
-        SumAccum<int> @intersection_size, @@set_size_A, @set_size_B;
-*ATTR*  SumAccum<FLOAT> @jaccard;
+        SumAccum<INT> @intersection_size, @@set_size_A, @set_size_B;
+        SumAccum<FLOAT> @similarity;
 
         Start (ANY) = {source};
         Start = SELECT s
@@ -30,21 +23,20 @@ Jaccard similarity = intersection_size / (size_A + size_B - intersection_size)
                  WHERE t != source
                  ACCUM t.@intersection_size += 1,
                        t.@set_size_B = t.outdegree("*edge-types*")
-*ATTR*           POST-ACCUM t.@jaccard = t.@intersection_size*1.0/(@@set_size_A + t.@set_size_B - t.@intersection_size)
-*ATTR*           ORDER BY t.@jaccard DESC
-*ATTR*           LIMIT topK
-*FILE*           POST-ACCUM @@result_topK += SIMILARITY_SCORE(source, t, t.@intersection_size*1.0/(@@set_size_A + t.@set_size_B - t.@intersection_size))
-*ACCM*           POST-ACCUM @@result_topK += SIMILARITY_SCORE(source, t, t.@intersection_size*1.0/(@@set_size_A + t.@set_size_B - t.@intersection_size))
-                 ;
+                 POST-ACCUM t.@similarity = t.@intersection_size*1.0/(@@set_size_A + t.@set_size_B - t.@intersection_size)
+                 ORDER BY t.@similarity DESC
+                 LIMIT topK;
+
 *ATTR*  Others = SELECT s
 *ATTR*           FROM Others:s
-*ATTR*           POST-ACCUM insert into *insert-edge-name* values(source, s, s.@jaccard);
+*ATTR*           POST-ACCUM insert into *insert-edge-name* values(source, s, s.@similarity);
 
-*ACCM*  PRINT @@result_topK;
+*ACCM*  PRINT Others.@similarity;
 
-*FILE*  f.println("Vertex1","Vertex2","Similarity");
-*FILE*  FOREACH item IN @@result_topK DO
-*FILE*          f.println(item.vertex1, item.vertex2, item.score);
-*FILE*  END;
+*FILE*  f.println("Vertex1", "Vertex2", "Similarity");
+*FILE*  Others = SELECT s
+*FILE*           FROM Others:s
+*FILE*           POST-ACCUM f.println(source, s, s.@similarity);
+
 }
 

--- a/graph_algorithms/algorithms/templates/louvain.gtmp
+++ b/graph_algorithms/algorithms/templates/louvain.gtmp
@@ -65,9 +65,9 @@
         iteration = 1;
         S = SELECT s 
             FROM Start:s -(*edge-types*:e)-> :t
-            #WHERE s.@cid != t.@cid  # since the default bestCluster is itself, don't need to calculate itself        
             WHERE s.@cid > t.@cid
-            ACCUM s.@largestDeltaQ += vDeltaQ(t, t.@cid, e.*edge-weight* - 2 * s.@weight * s.@weight/ @@totalWeight) # weightToCluster is just e.*edge-weight*
+            ACCUM s.@largestDeltaQ += vDeltaQ(t, t.@cid, e.*edge-weight* - 2 * s.@weight * s.@weight/ @@totalWeight) 
+                  # weightToCluster is just e.*edge-weight*
             POST-ACCUM INT bestCluster = s.@largestDeltaQ.top().cid,
                        IF s.@largestDeltaQ.size() > 0 and s.@largestDeltaQ.top().deltaQ > 0 and s.@cid != bestCluster THEN 
                                s.@cid = bestCluster
@@ -100,7 +100,13 @@
                 WHILE (loop < partitions) DO 
                         S = SELECT s 
                             FROM Start:s -(*edge-types*:e)-> :t
-                            WHERE s.@uid % partitions == loop AND abs(s.@weight - @@totIncidentCluster.get(s.@cid)) > epsilon OR abs(t.@weight - @@totIncidentCluster.get(t.@cid)) > epsilon OR (abs(s.@weight - @@totIncidentCluster.get(s.@cid)) < epsilon AND abs(t.@weight - @@totIncidentCluster.get(t.@cid)) < epsilon AND s.@cid > t.@cid)   # at least one cluster not only itself, or use smaller label
+                            WHERE s.@uid % partitions == loop    # for different split
+                                  # At least one cluster not singlet(a cluster on its own). If both clusters are singlets, consider only when the label of target is smaller to avoid swap
+                                  AND (( abs(s.@weight - @@totIncidentCluster.get(s.@cid)) > epsilon   # s is not a singlet 
+                                  OR abs(t.@weight - @@totIncidentCluster.get(t.@cid)) > epsilon )     # or t is not a singlet
+                                  OR (abs(s.@weight - @@totIncidentCluster.get(s.@cid)) < epsilon      # s is a singlet 
+                                  AND abs(t.@weight - @@totIncidentCluster.get(t.@cid)) < epsilon      # t is also a singlet
+                                  AND s.@cid > t.@cid) )                                               # consider only when target label is smaller
                             ACCUM s.@weightToCluster += (t.@cid -> e.*edge-weight*)
                             POST-ACCUM INT bestCluster = s.@cid,
                                        FLOAT maxDeltaQ = 0.0,
@@ -281,7 +287,7 @@
 *ATTR*                     , s.*vIntAttr* = s.@cid
 *FILE*                     , f_comm.println(s, s.@cid)
                            ;
-
+        log(TRUE, @@clusterSizes.size());
 
         IF distribution ==0 THEN
                 FOREACH (cluster, csize) IN @@clusterSizes DO

--- a/graph_algorithms/algorithms/templates/louvain.gtmp
+++ b/graph_algorithms/algorithms/templates/louvain.gtmp
@@ -1,87 +1,308 @@
-*ATTR*CREATE QUERY louvain*EXT* () FOR GRAPH *graph* {
-*ACCM*CREATE QUERY louvain*EXT* () FOR GRAPH *graph* {
-*FILE*CREATE QUERY louvain*EXT* (FILE f) FOR GRAPH *graph* {
-# Louvain Modularity Method for Community Detection
+*ATTR*CREATE QUERY louvain*EXT*(INT iter1 = 10, INT iter2 = 10, INT iter3 = 10, INT split = 10, INT distribution = 0, INT debug = 2 ) FOR GRAPH *graph* {
+*ACCM*CREATE QUERY louvain*EXT*(INT iter1 = 10, INT iter2 = 10, INT iter3 = 10, INT split = 10, INT distribution = 0, INT debug = 2 ) FOR GRAPH *graph* {
+*FILE*CREATE QUERY louvain*EXT*(INT iter1 = 10, INT iter2 = 10, INT iter3 = 10, INT split = 10, INT distribution = 0, INT debug = 2, FILE f_comm, FILE f_dist) FOR GRAPH *graph* {
+ /*
+ * Parallel Louvain Method with Refinement
+ * https://arxiv.org/pdf/1304.4453
+ * The minimum label heuristics are implemented: https://doi.org/10.1016/j.parco.2015.03.003
+ 
+ * iter: There are three phases in the algorithm -- move, merge and refine. Their max number of iterations are set by iter1, iter2, iter3 respectively.
+ * split: To save memory, split number is 10 by default. When the split number is larger, the query is closer to sequential Louvain Method, which is slower. When the split number is 1, the query is parallel, but requires more memory. 
+ * distribution: 0, only list number; 1, also list members
+ * debug: 0, no modularity info; 1, show debug log; 2, modularity for each iteration
+ * f_comm, f_dist: files to store community label and community distribution
+*/
+        
+        TYPEDEF TUPLE <INT csize, INT number> ClusterNum;
+        TYPEDEF TUPLE <VERTEX node, INT cid, FLOAT deltaQ> vDeltaQ;
+        HeapAccum<vDeltaQ>(1, deltaQ DESC, cid ASC) @largestDeltaQ;   # if deltaQ is the same, select the one with mininal vid 
+        MapAccum<INT, FLOAT> @@totIncidentCluster;   # sun of weight incident to clusters
+        MapAccum<INT, INT> @@clusterSizes;                # size of a cluster
+        MapAccum<INT, FLOAT> @weightToCluster;  # weight from one vertex incident to that cluster
+        SumAccum<FLOAT> @@totalWeight;   # total weight of all edges
+        SumAccum<FLOAT> @weight;          # total weight incident to this vertex
+        SumAccum<FLOAT> @cweight;       # total weight incident to this aggregate vertex
+        SumAccum<INT> @uid;        # which vertex it belongs to
+        SumAccum<INT> @cid;        # which cluster it belongs to
+        SumAccum<INT> @vid;        # internal id
+        SumAccum<FLOAT> @deltaQ;         # contribution to the modularity
+        SumAccum<FLOAT> @@modularity;
+        SumAccum<FLOAT> @@modularity2;
+        MapAccum<INT, MapAccum<INT, FLOAT>> @@weightToClusterMap;   # calculate edges between communities 
+        MapAccum<INT, SetAccum<INT>> @@moveComm; # map of communities that changed its community id
+        MapAccum<INT, MinAccum<VERTEX>> @@representMap;
+        SetAccum<VERTEX> @@representSet;
+        MapAccum<INT, FLOAT> @@vertexMap;
+        MapAccum<INT, MapAccum<INT, FLOAT>> @@edgeMap;
+        HeapAccum<ClusterNum>(100, csize ASC) @@clusterDist;
+        MapAccum<INT, INT> @@clusterMap;
+        MapAccum<INT, ListAccum<INT>> @@clusterMembers;
+        FLOAT last_modularity = 0;
+        FLOAT last_modularity2 = 0;
+        INT iteration;
+        INT Iter1; 
+        FLOAT epsilon = 0.0001;
+        INT iteration2;
+        INT partitions;
+        INT loop;
 
-        # map: <cluster ID, value>
-        MapAccum<int, int> @@edgeCntWithinCluster;     # edge count inside clusters
-        MapAccum<int, int> @@edgeCntIncidentCluster;   # edge count incident to clusters
-        MapAccum<int, int> @@compSizes;                # size of a cluster
-        MapAccum<int, int> @clusterEdgeCnt;  # edge count incident to that cluster
-
-        SumAccum<int> @@totalNumEdges;   # total number of edges
-        SumAccum<int> @edgeCnt;          # total edge count of vertex
-        SumAccum<int> @cluster;        # which cluster it belongs to
-        SumAccum<float> @deltaQ;         # contribution to the modularity
-
-        OrAccum @@changed;               # true if cluster membership changed in this iterator
-  
-        Start = {*vertex-types*};
-
+        partitions = split;
+        CASE WHEN split < 1 THEN
+                partitions = 1;
+        END;
+        
 # Initialize: count edges and set a unique cluster ID for each vertex
-        Start = SELECT s 
-                FROM Start:s -(*edge-types*:e)-> :t
-                ACCUM @@totalNumEdges += 1,
-                      s.@edgeCnt += 1
-                POST-ACCUM s.@cluster = getvid(s); # Label each vertex with its own internal ID
-        @@changed = true;
+        Start = {*vertex-types*};
+        S = SELECT s 
+            FROM Start:s -(*edge-types*:e)-> :t
+            ACCUM @@totalWeight += e.*edge-weight*,
+                  s.@weight += e.*edge-weight*
+            POST-ACCUM s.@vid = getvid(s),
+                       s.@uid = s.@vid,
+                       s.@cid = s.@vid;  # Label each vertex with its own internal ID
 
+# Special first iteration of Phase 1
+        iteration = 1;
+        S = SELECT s 
+            FROM Start:s -(*edge-types*:e)-> :t
+            #WHERE s.@cid != t.@cid  # since the default bestCluster is itself, don't need to calculate itself        
+            WHERE s.@cid > t.@cid
+            ACCUM s.@largestDeltaQ += vDeltaQ(t, t.@cid, e.*edge-weight* - 2 * s.@weight * s.@weight/ @@totalWeight) # weightToCluster is just e.*edge-weight*
+            POST-ACCUM INT bestCluster = s.@largestDeltaQ.top().cid,
+                       IF s.@largestDeltaQ.size() > 0 and s.@largestDeltaQ.top().deltaQ > 0 and s.@cid != bestCluster THEN 
+                               s.@cid = bestCluster
+                       END,
+                       s.@largestDeltaQ.clear();
+        
+        S = SELECT s
+            FROM Start:s-(*edge-types*:e)-:t
+            WHERE s.@cid == t.@cid
+            ACCUM @@modularity += e.*edge-weight* - s.@weight * t.@weight / (@@totalWeight);
+
+        @@modularity = @@modularity / @@totalWeight;                      
+        PRINT iteration AS Phase1Iter, @@modularity;
+        log(debug > 0, "[redrain]#move", iteration, @@modularity);
+        
+# Phase 1 -- Move
 # For each vertex, calculate the change in modularity FROM adding it to each of the nearby clusters
 # Add vertex to cluster with highest positive change in modularity
 # Repeat the above until no vertices change cluster anymore
-        WHILE @@changed == true DO
-                @@changed = false;
-                Start = SELECT s 
-                        FROM Start:s -(*edge-types*:e)-> :t
-                        ACCUM s.@clusterEdgeCnt += (t.@cluster->1),
-                                // if this is an incident edge
-                              IF s.@cluster != t.@cluster THEN
-                                      @@edgeCntIncidentCluster += (s.@cluster->1)
-                              ELSE
-                                      @@edgeCntWithinCluster += (s.@cluster->1)
-                              END
-                        POST-ACCUM
-                                INT resultCluster = s.@cluster,
-                                INT m = @@totalNumEdges,
-                                FLOAT maxDeltaQ = -999,
-                                FLOAT deltaQ_new = 0,
-                                FOREACH (cluster, edgeCnt) IN s.@clusterEdgeCnt DO
-                                        INT within = @@edgeCntWithinCluster.get(cluster),
-                                        INT incident = @@edgeCntIncidentCluster.get(cluster),
-                                        deltaQ_new = ((within + s.@clusterEdgeCnt.get(cluster)) / (2.0*m))
-                                                     - pow((incident + s.@edgeCnt)/(2.0*m),2)
-                                                     - (within / (2.0*m)
-                                                     - pow((incident/(2.0*m)),2)
-                                                     - pow((s.@edgeCnt/(2.0*m)),2)),
-                                        IF deltaQ_new > maxDeltaQ AND deltaQ_new > s.@deltaQ AND deltaQ_new > 0 THEN
-                                                maxDeltaQ = deltaQ_new,
-                                                resultCluster = cluster
-                                        END
-                                END,
-                                IF s.@cluster != resultCluster THEN
-                                        s.@cluster = resultCluster,
-                                        s.@deltaQ = maxDeltaQ,
-                                        @@changed += true
-                                END,
-                                s.@clusterEdgeCnt.clear()
-                        ;
-                @@edgeCntWithinCluster.clear();
-                @@edgeCntIncidentCluster.clear();
+        S = SELECT s 
+            FROM Start:s
+            ACCUM @@totIncidentCluster += (s.@cid -> s.@weight); 
+              
+        iteration = 1;
+        Iter1 = iter1 - 1;
+              
+        WHILE (iteration < 2 OR @@modularity - last_modularity > epsilon) LIMIT Iter1 DO
+                iteration += 1;
+                loop = 0;
+                WHILE (loop < partitions) DO 
+                        S = SELECT s 
+                            FROM Start:s -(*edge-types*:e)-> :t
+                            WHERE s.@uid % partitions == loop AND abs(s.@weight - @@totIncidentCluster.get(s.@cid)) > epsilon OR abs(t.@weight - @@totIncidentCluster.get(t.@cid)) > epsilon OR (abs(s.@weight - @@totIncidentCluster.get(s.@cid)) < epsilon AND abs(t.@weight - @@totIncidentCluster.get(t.@cid)) < epsilon AND s.@cid > t.@cid)   # at least one cluster not only itself, or use smaller label
+                            ACCUM s.@weightToCluster += (t.@cid -> e.*edge-weight*)
+                            POST-ACCUM INT bestCluster = s.@cid,
+                                       FLOAT maxDeltaQ = 0.0,
+                                       FLOAT deltaQ_new = 0.0,
+                                       FOREACH (cluster, weightToC) IN s.@weightToCluster DO   #would be better if this can be distributed
+                                               FLOAT incident = @@totIncidentCluster.get(cluster),
+                                               deltaQ_new = weightToC - 2 * incident * s.@weight/ @@totalWeight,
+                                               IF deltaQ_new > maxDeltaQ OR (abs(deltaQ_new - maxDeltaQ) < epsilon AND cluster < bestCluster) THEN   # when deltaQ_new is equal to maxDeltaQ, and the cluster label is smaller, also change 
+                                                       maxDeltaQ = deltaQ_new,
+                                                       bestCluster = cluster
+                                               END
+                                       END,
+                                       IF s.@cid != bestCluster THEN 
+                                               @@totIncidentCluster += (s.@cid -> (-1 * s.@weight)),
+                                               @@totIncidentCluster += (bestCluster -> s.@weight),
+                                               s.@cid = bestCluster
+                                       END,
+                                       s.@weightToCluster.clear();
+                        loop = loop + 1;
+                END;
+                last_modularity = @@modularity;
+                @@modularity = 0;
+                T1 = SELECT s
+                     FROM Start:s-(*edge-types*:e)-:t
+                     WHERE s.@cid == t.@cid
+                     ACCUM @@modularity += e.*edge-weight* - s.@weight * t.@weight / (@@totalWeight);
+                @@modularity = @@modularity / @@totalWeight;                      
+                PRINT iteration AS Phase1Iter, @@modularity;
+                log(debug > 0, "[redrain]#move", iteration, @@modularity);
         END;
 
-        Start = {*vertex-types*};
+# Phase 2 --  Merge     
+        iteration2 = 0;
+        WHILE (iteration2 < 2 OR @@modularity2 - last_modularity2 > epsilon) LIMIT iter2 DO
+                iteration2 += 1;
+                Start = SELECT s
+                        FROM Start:s
+                        ACCUM s.@uid = s.@cid;      
+                # Select the vertices with minimal internal id to represent the coarsened graph
+                Start = SELECT s
+                        FROM Start:s 
+                        ACCUM @@representMap += (s.@cid -> s);
+        
+                FOREACH (key, value) IN @@representMap DO
+                        @@representSet += value;                       
+                END;      
+                represent = {@@representSet};
+                @@representMap.clear();
+                @@representSet.clear();
+                log(debug > 0, "[redrain]#2_merge", represent.size()); #@@clusterSizes.size());
 
-*ATTR*  Start = SELECT s FROM Start:s 
-*ATTR*          POST-ACCUM s.*vIntAttr* = s.@cluster;
+            # Get @cweight from totalIncident
+                represent = SELECT s
+                            FROM represent:s
+                            ACCUM s.@cweight = @@totIncidentCluster.get(s.@uid),
+                                  @@clusterSizes += (s.@cid -> 1);
 
-*ACCM*  Start = SELECT s FROM Start:s
-*ACCM*          POST-ACCUM @@compSizes += (s.@cluster -> 1);
-*ACCM*  PRINT @@compSizes;
-*ACCM*  PRINT Start.@cluster;
+                log(debug > 1, "[redrain]#2_merge", @@weightToClusterMap.size());
+                iteration = 0;
+                last_modularity = 0;
+                @@modularity = 0;
+     
+                WHILE (iteration < 2 OR @@modularity - last_modularity > epsilon) limit iter1 DO
+                        iteration += 1;
+        
+                        # Calculate.*edge-weight* incident from vertex to cluster in coarsened graph; change every interation
+                        S = SELECT s
+                            FROM Start:s -(*edge-types*:e)-:t
+                            WHERE s.@cid != t.@cid AND @@totIncidentCluster.get(s.@uid) > 0 AND @@totIncidentCluster.get(t.@cid) > 0   #@@totIncidentCluster keeps changing, can be 0
+                            ACCUM @@weightToClusterMap += (s.@uid -> (t.@cid -> e.*edge-weight*));  # from s, incident to some clusters. Not consider the same cluster
+                        represent = SELECT s 
+                                    FROM represent:s
+                                    POST-ACCUM INT bestCluster = s.@cid,
+                                               FLOAT maxDeltaQ = 0.0,
+                                               FLOAT deltaQ_new = 0.0,
+                                               FOREACH (cluster, weightToC) IN @@weightToClusterMap.get(s.@uid) DO 
+                                                       FLOAT incident = @@totIncidentCluster.get(cluster),
+                                                       IF @@clusterSizes.get(s.@cid) == 1 AND @@clusterSizes.get(cluster) == 1 AND s.@cid < cluster THEN
+                                                               CONTINUE
+                                                       END,
+                                                       deltaQ_new = weightToC - 2 * incident * s.@cweight/ @@totalWeight, #total weight should be the same
+                                                       IF deltaQ_new > maxDeltaQ OR abs(deltaQ_new - maxDeltaQ) < epsilon AND cluster < bestCluster THEN      # new cluster is smaller then the current best cluster
+                                                               maxDeltaQ = deltaQ_new,
+                                                               bestCluster = cluster
+                                                       END
+                                               END,
+                                               IF s.@cid != bestCluster THEN
+                                                       @@totIncidentCluster += (s.@cid -> (-1 * s.@cweight)),
+                                                       @@totIncidentCluster += (bestCluster -> s.@cweight),
+                                                       @@moveComm += (s.@uid -> bestCluster),
+                                                       @@clusterSizes += (s.@cid -> -1),
+                                                       @@clusterSizes += (bestCluster -> 1),
+                                                       s.@cid = bestCluster
+                                               END;
+                        log(debug > 1, "[redrain]#2_merge", @@weightToClusterMap.size()); 
+                        @@weightToClusterMap.clear();
+                   
+                        log(debug > 1, "[redrain]#2_move:", @@moveComm.size());
+                        # move nodes
+                        S = SELECT s
+                            FROM Start:s
+                            WHERE @@moveComm.containsKey(s.@uid)
+                            POST-ACCUM FOREACH v IN @@moveComm.get(s.@uid) DO
+                                               s.@cid = v
+                                       END;
+                        @@moveComm.clear();
+    
+                        last_modularity = @@modularity;           
+                        @@modularity = 0;
+                
+                        S = SELECT s
+                            FROM Start:s-(*edge-types*:e)-:t
+                            WHERE s.@cid == t.@cid
+                            ACCUM @@modularity += e.*edge-weight* - s.@weight * t.@weight / (@@totalWeight);
+                            @@modularity = @@modularity / @@totalWeight;
+                            PRINT iteration AS Phase1Iter, @@modularity;
+                        log(debug > 0, "[redrain]#2_move", iteration, @@modularity);
+                END;
+        
+                S = SELECT s
+                    FROM represent:s
+                    ACCUM s.@cweight = 0;
+                @@clusterSizes.clear();
+        
+                last_modularity2 = @@modularity2;
+                @@modularity2 = @@modularity;
+                PRINT iteration2 AS Phase2Iter, @@modularity2;
+                log(debug > 0, "[redrain]#2_merge", iteration2, @@modularity2);
+                                      
+        END;
+        
+        
+# Phase 3 -- Refinement
+        iteration = 0;
+        @@modularity = 0;
+        WHILE (iteration < 2 OR @@modularity - last_modularity > epsilon) LIMIT iter3 DO
+                iteration += 1;
+                S = SELECT s 
+                    FROM Start:s -(*edge-types*:e)-> :t
+                    WHERE abs(s.@weight - @@totIncidentCluster.get(s.@cid)) > epsilon OR abs(t.@weight - @@totIncidentCluster.get(t.@cid)) > epsilon OR (abs(s.@weight - @@totIncidentCluster.get(s.@cid)) < epsilon AND abs(t.@weight - @@totIncidentCluster.get(t.@cid)) < epsilon AND s.@cid > t.@cid)   # at least one cluster not only itself, or use smaller label
+                    ACCUM s.@weightToCluster += (t.@cid -> e.*edge-weight*)
+                    POST-ACCUM
+                            INT bestCluster = s.@cid,
+                            FLOAT maxDeltaQ = 0.0,
+                            FLOAT deltaQ_new = 0.0,
+                            FOREACH (cluster, weightToC) IN s.@weightToCluster DO   #would be better if this can be distributed
+                                    FLOAT incident = @@totIncidentCluster.get(cluster),
+                                    deltaQ_new = weightToC - 2 * incident * s.@weight/ @@totalWeight,
+                                    IF deltaQ_new > maxDeltaQ OR (abs(deltaQ_new - maxDeltaQ) < epsilon AND cluster < bestCluster) THEN   # when deltaQ_new is equal to maxDeltaQ, and the cluster label is smaller, also change 
+                                            maxDeltaQ = deltaQ_new,
+                                            bestCluster = cluster
+                                    END
+                            END,
+                            IF s.@cid != bestCluster THEN 
+                                    @@totIncidentCluster += (s.@cid -> (-1 * s.@weight)),
+                                    @@totIncidentCluster += (bestCluster -> s.@weight),
+                                    s.@cid = bestCluster
+                            END,
+                            s.@weightToCluster.clear();
 
-*FILE*  f.println("Vertex_ID", "Cluster_ID");
-*FILE*  Start = SELECT s FROM Start:s
-*FILE*          POST-ACCUM f.println(s, s.@cluster);
+                last_modularity = @@modularity;
+                @@modularity = 0;
+                T1 = SELECT s
+                     FROM Start:s-(*edge-types*:e)-:t
+                     WHERE s.@cid == t.@cid
+                     ACCUM @@modularity += e.*edge-weight* - s.@weight * t.@weight / (@@totalWeight);
+                @@modularity = @@modularity / @@totalWeight;                      
+                PRINT iteration AS Phase3Iter, @@modularity;
+                log(debug > 0, "[redrain]#refine", iteration, @@modularity);
+        END;
+        
+                
+*ACCM*  Print Start.@cid;
+*FILE*  f_comm.println("Vertex_ID", "community_id");
+        Start = {ANY};
+        Start = SELECT s FROM Start:s
+                POST-ACCUM @@clusterSizes += (s.@cid -> 1)
+*ATTR*                     , s.*vIntAttr* = s.@cid
+*FILE*                     , f_comm.println(s, s.@cid)
+                           ;
+
+
+        IF distribution ==0 THEN
+                FOREACH (cluster, csize) IN @@clusterSizes DO
+                        @@clusterMap += (csize -> 1);
+                END;
+                FOREACH (csize, number) IN @@clusterMap DO
+                        @@clusterDist += ClusterNum(csize, number);
+                END;
+*ACCM*          PRINT @@clusterDist;
+*ATTR*          PRINT @@clusterDist;
+*FILE*          FOREACH item IN @@clusterDist DO
+*FILE*                  f_dist.println(item.csize, item.number);
+*FILE*          END;
+        ELSE
+                FOREACH (cluster, csize) IN @@clusterSizes DO
+                        @@clusterMembers += (csize -> cluster);
+                END;
+*ACCM*          PRINT @@clusterMembers;
+*ATTR*          PRINT @@clusterMembers;
+*FILE*          FOREACH (key, value) IN @@clusterMembers DO
+*FILE*                  f_dist.println(key, value);
+*FILE*          END;
+        END;
 }
-
-#INSTALL QUERY louvain*EXT*

--- a/graph_algorithms/algorithms/templates/mst.gtmp
+++ b/graph_algorithms/algorithms/templates/mst.gtmp
@@ -1,0 +1,53 @@
+*ATTR*CREATE QUERY mst*EXT* (VERTEX source) FOR GRAPH *graph* {
+*ACCM*CREATE QUERY mst*EXT* (VERTEX source) FOR GRAPH *graph* {
+*FILE*CREATE QUERY mst*EXT* (VERTEX source, FILE f) FOR GRAPH *graph* {
+/* Minimal Spanning Tree (MST)
+Given an undirected graph, and a source vertex, print out a MST for the connected subgraph which contains the source vertex.
+1. Start with a set A = {source vertex}
+2. For all vertices in A, find another vertex y in the graph but not A which is connected to a vertex x in A such that the weight on the edge e(x,y) is the smallest among all such edges from a vertex in A to a vertex not in A. Add y to A, and add the edge (x,y) to MST
+3. Repeat 2 until A has no edge linking to any other vertex in the graph.
+The ACCM version shows display by default.  
+*/
+*ATTR*  TYPEDEF TUPLE<VERTEX fromV, VERTEX toV, FLOAT weight> EDGE_WEIGHT;
+*ACCM*  TYPEDEF TUPLE<VERTEX toV, EDGE their_edge, FLOAT weight> EDGE_WEIGHT;
+*FILE*  TYPEDEF TUPLE<VERTEX fromV, VERTEX toV, FLOAT weight> EDGE_WEIGHT;
+        HeapAccum<EDGE_WEIGHT>(1, weight ASC) @@chosen_edge; //only need to keep the minimal tuple
+*ACCM*  SetAccum<EDGE> @@mst;
+*FILE*  SetAccum<EDGE_WEIGHT> @@mst;
+        OrAccum @chosen;
+
+        A = {source};
+        // initialize the source vertex
+        Current = SELECT a
+                  FROM A:a
+                  ACCUM a.@chosen = true;
+
+        WHILE (Current.size() > 0) DO
+                Current = SELECT t
+                          FROM A:s -(*edge-types*:e) -> :t
+                          WHERE t.@chosen == false    // vertex not in A
+*ATTR*                    ACCUM @@chosen_edge += EDGE_WEIGHT(s, t, e.*edge-weight*)
+*ACCM*                    ACCUM @@chosen_edge += EDGE_WEIGHT(t, e, e.*edge-weight*)
+*FILE*                    ACCUM @@chosen_edge += EDGE_WEIGHT(s, t, e.*edge-weight*)
+                          POST-ACCUM IF t == @@chosen_edge.top().toV THEN    
+                                              t.@chosen = TRUE      // mark the chosen vertex to add into A
+                                     END
+                          HAVING t.@chosen' == false and t.@chosen == true;
+                IF @@chosen_edge.size() > 0 THEN
+*ATTR*                  S = SELECT s
+*ATTR*                      FROM Current:s -(*edge-types*:e) -> :t
+*ATTR*                      WHERE t == @@chosen_edge.top().fromV
+*ATTR*                      ACCUM e.*eBoolAttr* = TRUE;
+*ACCM*                  @@mst += @@chosen_edge.top().their_edge;
+*FILE*                  @@mst += @@chosen_edge.top();
+                END;    
+                @@chosen_edge.clear();
+                A = A UNION Current;      // update A
+        END;
+
+*ACCM*  PRINT @@mst;
+*FILE*  f.println("From", "To", "Weight");
+*FILE*  FOREACH e IN @@mst DO 
+*FILE*      f.println(e.fromV, e.toV, e.weight);
+*FILE*  END;
+}

--- a/graph_algorithms/algorithms/templates/pageRank_wt.gtmp
+++ b/graph_algorithms/algorithms/templates/pageRank_wt.gtmp
@@ -18,7 +18,7 @@
 
         Start = {*vertex-types*};   #  Start with all vertices of specified type(s)
         Start = SELECT s
-                FROM Start:s -(Friend:e) -> :t
+                FROM Start:s -(*edge-types*:e) -> :t
                 ACCUM s.@total_weight += e.weight;  # Calculate the total weight for each vertex
 
         WHILE @@maxDiff > maxChange LIMIT maxIter DO


### PR DESCRIPTION
1. Simplify the logic of single source similarity algorithms, which improves the performance.
2. Change the topK result from global topK to topK for each vertex.