### PR TITLE
Add url for a Python gsql and restpp client

### DIFF
--- a/third-party/README.md
+++ b/third-party/README.md
@@ -4,3 +4,6 @@
 
 # Gradle plugins
 - [Giraffle](https://github.com/Optum/giraffle) by jmeekhof: _"The dsl allows you to describe connections to a Tigergraph server."_
+
+# GSQL and RESTPP remote clients
+- [gsql client for Python](https://github.com/dingmaotu/gsql_client) by dingmaotu: _"a Python implementation of gsql and restpp client"_


### PR DESCRIPTION
https://github.com/dingmaotu/gsql_client is a Python equivalent of gsql_client.jar and also wraps the RESTPP RESTful API endpoints. It enables one to programmatically submit gsql commands and files.