### PR TITLE
Fixed issues with time zones other than UTC.

### DIFF
--- a/tools/diag/gcollect/src/gcollect/main.go
+++ b/tools/diag/gcollect/src/gcollect/main.go
@@ -73,7 +73,7 @@ var argsWithoutProg string
 var name2client map[string]*ssh.Client
 // Used to sync with slave nodes
 var sync_chan chan int
-// Mapping from node id to IP address 
+// Mapping from node id to IP address
 var name2ip map[string]string
 // A map contains all the components specified to be collected.
 var need_components_map map[string]int
@@ -188,14 +188,14 @@ func collectDebugInfo() {
   // Get system info
   sysInfo := output_dir + "/sysInfo.txt"
   utils.LocalRun("echo '>>>>>>>>>>>>>> cat /etc/os-release <<<<<<<<<<<<<<' > " + sysInfo)
-  utils.LocalRun("cat /etc/os-release >> " + sysInfo)
+  utils.LocalRunIgnoreError("cat /etc/os-release >> " + sysInfo)
   utils.LocalRun("echo '\n>>>>>>>>>>>>>> gadmin version <<<<<<<<<<<<<<' >> " + sysInfo)
   utils.LocalRunIgnoreError("~/.gium/gadmin version >> " + sysInfo + " 2>&1")
   utils.LocalRun("echo '\n>>>>>>>>>>>>>> TigerGraph root Dir: " + tgRootDir + "' >> " + sysInfo)
   utils.LocalRun("echo '\n>>>>>>>>>>>>>> \"df -lh\" on m1 <<<<<<<<<<<<<<' >> " + sysInfo)
-  utils.LocalRun("df -lh >> " + sysInfo)
+  utils.LocalRunIgnoreError("df -lh >> " + sysInfo)
   utils.LocalRun("echo '\n>>>>>>>>>>>>>> \"free -g\" on m1 <<<<<<<<<<<<<<' >> " + sysInfo)
-  utils.LocalRun("free -g >> " + sysInfo)
+  utils.LocalRunIgnoreError("free -g >> " + sysInfo)
   utils.LocalRun("echo '\n>>>>>>>>>>>>>> \"dmesg | grep -i oom\" on m1 <<<<<<<<<<<<<<' >> " + sysInfo)
   _, err := utils.LocalRunIgnoreError("dmesg | grep -i oom >> " + sysInfo)
 
@@ -436,7 +436,7 @@ func main() {
     startEpoch = endEpoch - int64(tminus)
   } else {
     if start != "" {
-      t1, err := time.Parse(timeFormat, start)
+      t1, err := time.ParseInLocation(timeFormat, start, time.Local)
       if err != nil {
         fmt.Println(err)
         log.Fatal("Support format: 2006-01-02,15:04:05")
@@ -444,7 +444,7 @@ func main() {
       startEpoch = t1.Unix()
     }
     if end != "" {
-      t2, err := time.Parse(timeFormat, end)
+      t2, err := time.ParseInLocation(timeFormat, end, time.Local)
       if err != nil {
         fmt.Println(err)
         log.Fatal("Support format: 2006-01-02,15:04:05")
@@ -1055,4 +1055,3 @@ func filterLogs(outFolder string) {
       outFolder + "/gsql.log", patterns, startEpoch, endEpoch, before, after)
   }
 }
-

--- a/tools/diag/gcollect/src/logs/logs.go
+++ b/tools/diag/gcollect/src/logs/logs.go
@@ -644,7 +644,7 @@ func FilterLogsFunc(line2Epoch func(string) int64, logDir, outFile, prefix, suff
       continue
     }
 
-    // Ignore files not ending with specified suffix 
+    // Ignore files not ending with specified suffix
     if suffix != "" && !strings.HasSuffix(logInfo, suffix) {
       continue
     }
@@ -763,7 +763,7 @@ func GsqlLine2Epoch(line string) int64 {
     return -1
   }
   ts := line[2:19]
-  t, err := time.Parse(timeFormat, ts)
+  t, err := time.ParseInLocation(timeFormat, ts, time.Local)
   if err != nil {
     return -1
   }
@@ -778,11 +778,13 @@ func GsqlFilterLogs(logDir, outFile string, patterns []string,
 
 // Logs filter for Nginx
 func NginxLine2Epoch(line string) int64 {
-  const timeFormat = "02/Jan/2006:15:04:05 +0000"
+  const timeFormat = "02/Jan/2006:15:04:05"
   start := strings.Index(line, "[")
   end := strings.Index(line, "]")
-  ts := line[start+1:end]
-  t, err := time.Parse(timeFormat, ts)
+  tmp := line[start+1:end]
+  end = strings.Index(tmp, " ")
+  ts := tmp[0:end]
+  t, err := time.ParseInLocation(timeFormat, ts, time.Local)
   if err != nil {
     log.Fatalf("Failed to convert \"%s\" to epoch with error: %s", ts, err)
   }
@@ -804,7 +806,7 @@ func kafkaLine2Epoch(line string) int64 {
     return -1
   }
   ts := line[start+1:end-4]
-  t, err := time.Parse(timeFormat, ts)
+  t, err := time.ParseInLocation(timeFormat, ts, time.Local)
   if err != nil {
     return -1
   }
@@ -829,7 +831,7 @@ func guiLine2Epoch(line string) int64 {
   if (strings.Index(str, "T") < 0) {
     timeFormat = "2006-01-02 15:04:05"
   }
-  t, err := time.Parse(timeFormat, str)
+  t, err := time.ParseInLocation(timeFormat, str, time.Local)
   if err != nil {
     return -1
   }
@@ -841,4 +843,3 @@ func GuiFilterLogs(logDir, outFile, prefix string, patterns []string,
   FilterLogsFunc(guiLine2Epoch, logDir, outFile, prefix, "", patterns,
     startEpoch, endEpoch, before, after, 10)
 }
-

--- a/tools/diag/gcollect/src/utils/utils.go
+++ b/tools/diag/gcollect/src/utils/utils.go
@@ -7,7 +7,7 @@ import (
   "bytes"
   "io/ioutil"
   "path/filepath"
-  // "runtime/debug" 
+  // "runtime/debug"
   "fmt"
   "time"
   "net"
@@ -23,7 +23,7 @@ const (
     Compact // e.g., 20190507-221634.23248
     NoYear // e.g., I/W/E0507 22:16:49.801210
     Short // 22:47:09.824235
-    Epoch // e.g., %3|1557778930.317 
+    Epoch // e.g., %3|1557778930.317
     Unknown
 )
 
@@ -79,7 +79,7 @@ func Datetime2EpochShort(lastEpoch int64, ts string) int64 {
   t := time.Unix(lastEpoch, 0)
   year, month, day := t.Date()
   formattedTime := fmt.Sprintf("%4d-%02d-%02dT%sZ", year, month, day, ts[0:8])
-  t, err := time.Parse(time.RFC3339, formattedTime)
+  t, err := time.ParseInLocation(time.RFC3339, formattedTime, time.Local)
   if err != nil {
     errInfo := fmt.Sprintf("[IGNORED]Failed to convert \"%s\" to epoch with error: %s\n", ts, err)
     fmt.Printf(errInfo)
@@ -94,7 +94,7 @@ func Datetime2EpochShort(lastEpoch int64, ts string) int64 {
 func Datetime2EpochFull(ts string) int64 {
   const timeFormat = "2006-01-02 15:04:05"
   formattedTime := ts[0:19]
-  t, err := time.Parse(timeFormat, formattedTime)
+  t, err := time.ParseInLocation(timeFormat, formattedTime, time.Local)
   if err != nil {
     errInfo := fmt.Sprintf("Failed to convert \"%s\" to epoch with error: %s", ts, err)
     fmt.Println(errInfo)
@@ -108,7 +108,7 @@ func Datetime2EpochFull(ts string) int64 {
 func Datetime2EpochCompact(ts string) int64 {
   const timeFormat = "20060102-150405"
   formattedTime := ts[0:15]
-  t, err := time.Parse(timeFormat, formattedTime)
+  t, err := time.ParseInLocation(timeFormat, formattedTime, time.Local)
   if err != nil {
     errInfo := fmt.Sprintf("Failed to convert \"%s\" to epoch with error: %s", ts, err)
     fmt.Println(errInfo)
@@ -122,7 +122,7 @@ func Datetime2EpochCompact(ts string) int64 {
 func Datetime2EpochNoYear(year, str string) int64 {
   const timeFormat = "20060102 15:04:05"
   formattedTime := year + str[1:14]
-  t, err := time.Parse(timeFormat, formattedTime)
+  t, err := time.ParseInLocation(timeFormat, formattedTime, time.Local)
   if err != nil {
     errInfo := fmt.Sprintf("Failed to convert \"%s\" to epoch with error: %s", str, err)
     fmt.Println(errInfo)
@@ -277,7 +277,7 @@ func Connect(user, password, host, port, key string) (*ssh.Client, error) {
   return client, nil
 }
 
-// run several commands(separated with ";") one by one on remote server 
+// run several commands(separated with ";") one by one on remote server
 func RunCmds(client *ssh.Client, cmds string) (string, string) {
   cmdlist := strings.Split(cmds, ";")
   var stdoutBuff bytes.Buffer
@@ -401,4 +401,3 @@ func GetMyIpMap() map[string]int {
   }
   return myIpMap
 }
-


### PR DESCRIPTION
time.Parse() returns a time in UTC, so we use time.ParseInLocation() instead.