### PR TITLE
Add options to provide protocol, host and properties_file as inputs

### DIFF
--- a/tools/etl/tg-s3-parquet-load/README.md
+++ b/tools/etl/tg-s3-parquet-load/README.md
@@ -63,8 +63,11 @@ bash compile_and_run.sh $master_url $target_host $target_path $times $log_path
    1. $master_url is the url for Spark cluster manager
    2. $target_host
       * local (local csv mode, save as csv in local)
-      * ip address of TG database (post mode, post to TG)
+      * url of TG database (post mode, post to TG). It can be any of the below format. Protocol is either http or https.
+        * protocol://host:9000 (host is ip address)  
+        * protocol://host (host is route53/dns or alb whose target group port is 9000)
       * schema (schema mode, print schema and row count)
    3. $target_path is the path to store in the local machine if it is local csv mode. It must be absolute path.
    4. $times, just use 1
    5. $log_path the path that outputs the log, default is /tmp/sparkLoading/
+   6. $properties_file the properties file, default is s3.properties file in current directory.

--- a/tools/etl/tg-s3-parquet-load/compile_and_run.sh
+++ b/tools/etl/tg-s3-parquet-load/compile_and_run.sh
@@ -13,7 +13,7 @@ target_path="$cwd/uber_data"
 times=1
 log_path=""
 if [[ $# < 3 ]]; then
-  echo "Usage: ./compile_and_run.sh  master_url target_host target_path [times] [log_path]"
+  echo "Usage: ./compile_and_run.sh  master_url target_host target_path [times] [log_path] [properties_file]"
   exit 1
 fi
 
@@ -28,6 +28,11 @@ fi
 # specify log path, otherwise will use default: /tmp/sparkLoader
 if [[ $# > 4 ]]; then
   log_path=$5
+fi
+
+# specify properties file, otherwise will use default one
+if [[ $# > 5 ]]; then
+  properties_file=$6
 fi
 
 cd graphsql

--- a/tools/etl/tg-s3-parquet-load/graphsql/generateDataset.java
+++ b/tools/etl/tg-s3-parquet-load/graphsql/generateDataset.java
@@ -276,7 +276,7 @@ public class generateDataset implements Serializable {
 
   public void batchPost(String target_host, String rest_endpoint, StringBuilder payload) {
     // String requestUrl = "http://" + host + ":9000/dumpfile?filename=/tmp/data.csv";
-    String requestUrl = "http://" + target_host + ":9000/ddl?sep=,&tag=" + rest_endpoint + "&eol=%0A";
+    String requestUrl = target_host + "/ddl?sep=,&tag=" + rest_endpoint + "&eol=%0A";
     String response = sendPostRequest(requestUrl, payload.toString());
     JSONObject res_json;
     try {


### PR DESCRIPTION
At a minimum please provide the following:

### Description of the Change

The purpose of this change is to provide the following options as inputs based on different types of user environment settings.
a) protocol - as either http or https.
b) host - as either ip address or route53-endpoint/dns or alb. 
c) port - (9000) is made optional, which can only be provided with host as ip address. For other types of hosts the port can be set in AWS target group and won't be needed to provide in the code.
d) properties_file - ability to choose files from different locations having different names, as the code needs to support to run for multiple files to load data in parallel.

### Release Notes

- The tg-s3-parquet-load tool now provides you options to load data using https protocol, route53/dns/alb as host and S3 property files. 


