### PR TITLE
Update circleDetection.gsql

### DIFF
--- a/demos/guru_scripts/loop_detection_demo/queries/circleDetection.gsql
+++ b/demos/guru_scripts/loop_detection_demo/queries/circleDetection.gsql
@@ -266,7 +266,9 @@ CREATE QUERY circleDetection (vertex<account> srcId, int stepLowLimit = 3, int s
             tgt.@edgeTupleList = tgt.@newEdgeTupleList,
             tgt.@receiveNewPath = true,
             tgt.@newEdgeTupleList.clear()
-        END
+        END,
+        //clean up to reduce memory footprint
+        src.@edgeTupleList.clear()
       HAVING tgt.@receiveNewPath == true
     ;
 
@@ -302,7 +304,9 @@ CREATE QUERY circleDetection (vertex<account> srcId, int stepLowLimit = 3, int s
             END,
             tgt.@receiveNewPath = true,
             tgt.@newEdgeTupleList.clear()
-        END
+        END,
+        //clean up to reduce memory footprint
+        src.@edgeTupleList.clear()
       HAVING tgt.@receiveNewPath == true and tgt != srcId
     ;
 


### PR DESCRIPTION
Optimise memory usage of the algorithm - (based on my experience with this algorithm eating up 10x memory compared to idle state)

Cleaning up previously visited list accumulators greatly improves memory usage for this algorithm. This is done by removing the edgeTupleList from the source in the post-Accum step as the new paths are already forwarded to the next vertexes in the path. To my understanding, at that point, there is no need to store the paths in source vertex.
