### PR TITLE
GSQL V2 as default syntax version

### DIFF
--- a/demos/guru_scripts/docker/tutorial/3.x/gsql101/gsql101-step3.gsql
+++ b/demos/guru_scripts/docker/tutorial/3.x/gsql101/gsql101-step3.gsql
@@ -5,7 +5,7 @@ USE GRAPH social
 CREATE QUERY hello(VERTEX<person> p) {
   Start = {p};
   Result = SELECT tgt
-           FROM Start:s-(friendship:e) ->person:tgt;
+           FROM Start:s-(friendship:e) -person:tgt;
   PRINT Result;
 }
 
@@ -17,11 +17,11 @@ CREATE QUERY hello2 (VERTEX<person> p) {
   Start = {p};
 
   FirstNeighbors = SELECT tgt
-                   FROM Start:s -(friendship:e)-> person:tgt
+                   FROM Start:s -(friendship:e)- person:tgt
                    ACCUM tgt.@visited += true, s.@visited += true;
 
   SecondNeighbors = SELECT tgt
-                    FROM FirstNeighbors -(:e)-> :tgt
+                    FROM FirstNeighbors -(:e)- :tgt
                     WHERE tgt.@visited == false
                     POST_ACCUM @@avgAge += tgt.age;
 

--- a/demos/guru_scripts/docker/tutorial/3.x/gsql102/queries/multi-block1.gsql
+++ b/demos/guru_scripts/docker/tutorial/3.x/gsql102/queries/multi-block1.gsql
@@ -1,7 +1,7 @@
 USE GRAPH ldbc_snb
 
-# a computerd vertex set F is used to constrain the second pattern.
-INTERPRET QUERY () SYNTAX v2 {
+# a computed vertex set F is used to constrain the second pattern.
+INTERPRET QUERY () {
   SumAccum<int> @@cnt;
 
   F = SELECT t

--- a/demos/guru_scripts/docker/tutorial/3.x/gsql102/queries/multi-block2.gsql
+++ b/demos/guru_scripts/docker/tutorial/3.x/gsql102/queries/multi-block2.gsql
@@ -1,7 +1,7 @@
 USE GRAPH ldbc_snb
 
 # A and B are used to constraint the third pattern.
-INTERPRET QUERY () SYNTAX v2 {
+INTERPRET QUERY () {
   
   SumAccum<int> @@cnt;
 

--- a/demos/guru_scripts/docker/tutorial/3.x/gsql102/queries/multi-block3.gsql
+++ b/demos/guru_scripts/docker/tutorial/3.x/gsql102/queries/multi-block3.gsql
@@ -1,7 +1,7 @@
 USE GRAPH ldbc_snb
 
 # a computed vertex set A is used twice in the second pattern.
-INTERPRET QUERY () SYNTAX v2 {
+INTERPRET QUERY () {
 
   SumAccum<int> @@cnt;
 

--- a/demos/guru_scripts/docker/tutorial/3.x/gsql102/queries/multi-block4.gsql
+++ b/demos/guru_scripts/docker/tutorial/3.x/gsql102/queries/multi-block4.gsql
@@ -1,7 +1,7 @@
 USE GRAPH ldbc_snb
 
 # the same alias is used twice in a pattern
-INTERPRET QUERY () SYNTAX v2 {
+INTERPRET QUERY () {
 
   SumAccum<int> @@cnt;
 

--- a/demos/guru_scripts/docker/tutorial/3.x/gsql102/queries/multiple-hop1.gsql
+++ b/demos/guru_scripts/docker/tutorial/3.x/gsql102/queries/multiple-hop1.gsql
@@ -1,6 +1,6 @@
 USE GRAPH ldbc_snb
 
-INTERPRET QUERY () SYNTAX v2 {
+INTERPRET QUERY () {
 
   TagClass1 =  SELECT t
     FROM TagClass:s - (IS_SUBCLASS_OF>.IS_SUBCLASS_OF>.IS_SUBCLASS_OF>)-TagClass:t

--- a/demos/guru_scripts/docker/tutorial/3.x/gsql102/queries/multiple-hop2.gsql
+++ b/demos/guru_scripts/docker/tutorial/3.x/gsql102/queries/multiple-hop2.gsql
@@ -1,6 +1,6 @@
 USE GRAPH ldbc_snb
 
-INTERPRET QUERY () SYNTAX v2 {
+INTERPRET QUERY () {
 
   SumAccum<String> @continentName;
 

--- a/demos/guru_scripts/docker/tutorial/3.x/gsql102/queries/multiple-hop3.gsql
+++ b/demos/guru_scripts/docker/tutorial/3.x/gsql102/queries/multiple-hop3.gsql
@@ -1,6 +1,6 @@
 USE GRAPH ldbc_snb
 
-INTERPRET QUERY () SYNTAX v2 {
+INTERPRET QUERY () {
   SumAccum<int> @likesCnt;
 
   FavoriteAuthors =  SELECT t

--- a/demos/guru_scripts/docker/tutorial/3.x/gsql102/queries/multiple-post-accum.gsql
+++ b/demos/guru_scripts/docker/tutorial/3.x/gsql102/queries/multiple-post-accum.gsql
@@ -1,6 +1,6 @@
 USE GRAPH ldbc_snb
 
-INTERPRET QUERY () SYNTAX v2 {
+INTERPRET QUERY () {
 
   SumAccum<int> @cnt1;
   SumAccum<int> @cnt2;
@@ -11,7 +11,7 @@ INTERPRET QUERY () SYNTAX v2 {
             AND t.lastName LIKE "S%" AND year(msg.creationDate) == 2012
       ACCUM s.@cnt1 += 1 // execute this per match of the FROM pattern.
       POST-ACCUM s.@cnt2 += s.@cnt1 // execute once per s.
-      POST-ACCUM t.@cnt2 += 1; // executre once per t
+      POST-ACCUM t.@cnt2 += 1; // execute once per t
 
   PRINT R[R.firstName, R.lastName, R.@cnt1, R.@cnt2];
 }

--- a/demos/guru_scripts/docker/tutorial/3.x/gsql102/queries/one-hop-star1.gsql
+++ b/demos/guru_scripts/docker/tutorial/3.x/gsql102/queries/one-hop-star1.gsql
@@ -1,6 +1,6 @@
 USE GRAPH ldbc_snb
 
-INTERPRET QUERY () SYNTAX v2 {
+INTERPRET QUERY () {
 
   TagClass1 = SELECT t
               FROM TagClass:s -(IS_SUBCLASS_OF>*)- TagClass:t

--- a/demos/guru_scripts/docker/tutorial/3.x/gsql102/queries/one-hop-star2.gsql
+++ b/demos/guru_scripts/docker/tutorial/3.x/gsql102/queries/one-hop-star2.gsql
@@ -1,6 +1,6 @@
 USE GRAPH ldbc_snb
 
-INTERPRET QUERY () SYNTAX v2 {
+INTERPRET QUERY () {
 
   TagClass1 = SELECT t
               FROM TagClass:s -(IS_SUBCLASS_OF>*1)- TagClass:t

--- a/demos/guru_scripts/docker/tutorial/3.x/gsql102/queries/one-hop-star3.gsql
+++ b/demos/guru_scripts/docker/tutorial/3.x/gsql102/queries/one-hop-star3.gsql
@@ -1,6 +1,6 @@
 USE GRAPH ldbc_snb
 
-INTERPRET QUERY () SYNTAX v2 {
+INTERPRET QUERY () {
 
   TagClass1 = SELECT t
               FROM TagClass:s -(IS_SUBCLASS_OF>*1..2)- TagClass:t

--- a/demos/guru_scripts/docker/tutorial/3.x/gsql102/queries/one-hop-star4.gsql
+++ b/demos/guru_scripts/docker/tutorial/3.x/gsql102/queries/one-hop-star4.gsql
@@ -1,6 +1,6 @@
 USE GRAPH ldbc_snb
 
-INTERPRET QUERY () SYNTAX v2 {
+INTERPRET QUERY () {
 
   TagClass1 = SELECT t
               FROM TagClass:s -(IS_SUBCLASS_OF>*..2)- TagClass:t

--- a/demos/guru_scripts/docker/tutorial/3.x/gsql102/queries/one-hop-star5.gsql
+++ b/demos/guru_scripts/docker/tutorial/3.x/gsql102/queries/one-hop-star5.gsql
@@ -1,6 +1,6 @@
 USE GRAPH ldbc_snb
 
-INTERPRET QUERY () SYNTAX v2 {
+INTERPRET QUERY () {
 
   TagClass1 = SELECT t
               FROM TagClass:s -(IS_SUBCLASS_OF>*1..)- TagClass:t

--- a/demos/guru_scripts/docker/tutorial/3.x/gsql102/queries/one-hop1.gsql
+++ b/demos/guru_scripts/docker/tutorial/3.x/gsql102/queries/one-hop1.gsql
@@ -1,7 +1,7 @@
 USE GRAPH ldbc_snb
 
 # Example 1. Undirected Edge Pattern
-INTERPRET QUERY () SYNTAX v2 {
+INTERPRET QUERY () {
    friends = SELECT p
              FROM Person:s - (KNOWS:e)- Person:p
              WHERE s.firstName == "Viktor" AND s.lastName == "Akhiezer"

--- a/demos/guru_scripts/docker/tutorial/3.x/gsql102/queries/one-hop2.gsql
+++ b/demos/guru_scripts/docker/tutorial/3.x/gsql102/queries/one-hop2.gsql
@@ -1,7 +1,7 @@
 USE GRAPH ldbc_snb
 
 # Example 2. Right Directed Edge Pattern
-INTERPRET QUERY () SYNTAX v2 {
+INTERPRET QUERY () {
   SumAccum<int> @commentCnt = 0;
   SumAccum<int> @postCnt = 0;
 

--- a/demos/guru_scripts/docker/tutorial/3.x/gsql102/queries/one-hop3.gsql
+++ b/demos/guru_scripts/docker/tutorial/3.x/gsql102/queries/one-hop3.gsql
@@ -1,6 +1,6 @@
 USE GRAPH ldbc_snb
 
-INTERPRET QUERY () SYNTAX v2 {
+INTERPRET QUERY () {
   SumAccum<int> @commentCnt = 0;
   SumAccum<int> @postCnt = 0;
 

--- a/demos/guru_scripts/docker/tutorial/3.x/gsql102/queries/one-hop4.gsql
+++ b/demos/guru_scripts/docker/tutorial/3.x/gsql102/queries/one-hop4.gsql
@@ -1,7 +1,7 @@
 USE GRAPH ldbc_snb
 set query_timeout=60000
 
-INTERPRET QUERY () SYNTAX v2 {
+INTERPRET QUERY () {
   SumAccum<int> @commentCnt = 0;
   SumAccum<int> @postCnt = 0;
 

--- a/demos/guru_scripts/docker/tutorial/3.x/gsql102/queries/one-hop5.gsql
+++ b/demos/guru_scripts/docker/tutorial/3.x/gsql102/queries/one-hop5.gsql
@@ -1,6 +1,6 @@
 USE GRAPH ldbc_snb
 
-INTERPRET QUERY () SYNTAX v2 {
+INTERPRET QUERY () {
   SumAccum<int> @@cnt = 0;
 
   Result = SELECT tgt

--- a/demos/guru_scripts/docker/tutorial/3.x/gsql102/queries/recommendation1.gsql
+++ b/demos/guru_scripts/docker/tutorial/3.x/gsql102/queries/recommendation1.gsql
@@ -2,7 +2,7 @@ use graph ldbc_snb
 set query_timeout=60000
 DROP QUERY RecommendMessage
 
-CREATE QUERY RecommendMessage (String fn, String ln) SYNTAX v2 {
+CREATE QUERY RecommendMessage (String fn, String ln) {
 
   SumAccum<int> @TagInCommon;
   SumAccum<float> @SimilarityScore;

--- a/demos/guru_scripts/docker/tutorial/3.x/gsql102/queries/recommendation2.gsql
+++ b/demos/guru_scripts/docker/tutorial/3.x/gsql102/queries/recommendation2.gsql
@@ -2,7 +2,7 @@ USE GRAPH ldbc_snb
 SET query_timeout=60000
 DROP QUERY RecommendMessage
 
-CREATE QUERY RecommendMessage (String fn, String ln) SYNTAX v2 {
+CREATE QUERY RecommendMessage (String fn, String ln) {
 
   SumAccum<int> @MsgInCommon = 0;
   SumAccum<int> @MsgCnt = 0;


### PR DESCRIPTION
At a minimum please provide the following:

### Description of the Change

<!--

We must be able to understand the purpose of your change from this description.

-->
As of TG 3.5.0, GSQL syntax version will be V2 by default, so changing resources included in TG Docker image to be compatible with the V2 syntax.
