### PR TITLE
Added support for timeout and atomic.

### DIFF
--- a/tools/etl/tg-jdbc-driver/README.md
+++ b/tools/etl/tg-jdbc-driver/README.md
@@ -288,6 +288,8 @@ df.write.mode("overwrite").format("jdbc").options(
     "password" -> "tigergraph",
     "graph" -> "gsql_demo", // graph name
     "dbtable" -> "vertex Person", // vertex type
+    "timeout" -> "60", // query timeout in seconds
+    "atomic" -> "1", // 0 (default): nonatomic, 1: an atomic transaction
     "batchsize" -> "100",
     "debug" -> "0")).save()
 

--- a/tools/etl/tg-jdbc-driver/tg-jdbc-examples/src/main/java/com/tigergraph/jdbc/UpsertQuery.java
+++ b/tools/etl/tg-jdbc-driver/tg-jdbc-examples/src/main/java/com/tigergraph/jdbc/UpsertQuery.java
@@ -27,10 +27,17 @@ public class UpsertQuery
     properties.put("username", "tigergraph");
     properties.put("password", "tigergraph");
 
-    /**
-     * Specify the graph name, especially when multi-graph is enabled.
-     */
+    // Specify the graph name, especially when multi-graph is enabled.
     properties.put("graph", "gsql_demo");
+
+    // Specify the query timeout (in seconds)
+    properties.put("timeout", "60");
+
+    // This request is an atomic transaction
+    properties.put("atomic", "1");
+
+    // For load balancing
+    // properties.put("ip_list", "172.30.2.20,172.30.2.21");
 
     /**
      * For loading job

--- a/tools/etl/tg-jdbc-driver/tg-jdbc-restpp/src/main/java/com/tigergraph/jdbc/RestppConnection.java
+++ b/tools/etl/tg-jdbc-driver/tg-jdbc-restpp/src/main/java/com/tigergraph/jdbc/RestppConnection.java
@@ -78,6 +78,8 @@ public class RestppConnection extends Connection {
   private String lineSchema = null;
   private String src_vertex_type = null;
   private Integer debug = 0;
+  private Integer atomic = 0;
+  private Integer timeout = -1;
   private Integer level = 1;
   private String[] ipArray = null;
 
@@ -104,6 +106,14 @@ public class RestppConnection extends Connection {
 
       if (this.debug > 1) {
         System.out.println(">>> properties: " + properties);
+      }
+
+      if (properties.containsKey("atomic")) {
+        this.atomic = Integer.valueOf(properties.getProperty("atomic"));
+      }
+
+      if (properties.containsKey("timeout")) {
+        this.timeout = Integer.valueOf(properties.getProperty("timeout"));
       }
 
       // Get token for authentication.
@@ -411,6 +421,8 @@ public class RestppConnection extends Connection {
         break;
       } catch (Exception e) {
         if (retry >= max_retry - 1) {
+          System.out.println(">>> Request: " + request +
+             ", payload: " + json + ", error: " + e);
           throw new SQLException("Request: " + request +
              ", payload size: " + json.length() + ", error: " + e);
         }
@@ -436,18 +448,18 @@ public class RestppConnection extends Connection {
   }
 
   @Override public PreparedStatement prepareStatement(String query) throws SQLException {
-    return new RestppPreparedStatement(this, query, this.debug);
+    return new RestppPreparedStatement(this, query, this.debug, this.timeout, this.atomic);
   }
 
   @Override public PreparedStatement prepareStatement(String query,
     int resultSetType, int resultSetConcurrency) throws SQLException {
-    return new RestppPreparedStatement(this, query, this.debug);
+    return new RestppPreparedStatement(this, query, this.debug, this.timeout, this.atomic);
   }
 
   @Override public PreparedStatement prepareStatement(String query,
     int resultSetType, int resultSetConcurrency, int resultSetHoldability)
       throws SQLException {
-    return new RestppPreparedStatement(this, query, this.debug);
+    return new RestppPreparedStatement(this, query, this.debug, this.timeout, this.atomic);
   }
 
   @Override public DatabaseMetaData getMetaData() throws SQLException {
@@ -463,7 +475,7 @@ public class RestppConnection extends Connection {
   }
 
   @Override public java.sql.Statement createStatement() throws SQLException {
-    return new RestppStatement(this, this.debug);
+    return new RestppStatement(this, this.debug, this.timeout, this.atomic);
   }
 
   @Override public void commit() throws SQLException {

--- a/tools/etl/tg-jdbc-driver/tg-jdbc-restpp/src/main/java/com/tigergraph/jdbc/RestppPreparedStatement.java
+++ b/tools/etl/tg-jdbc-driver/tg-jdbc-restpp/src/main/java/com/tigergraph/jdbc/RestppPreparedStatement.java
@@ -25,12 +25,17 @@ public class RestppPreparedStatement extends PreparedStatement {
   private QueryType query_type;
   private String eol = null;
   private String sep = null;
+  private int timeout;
+  private int atomic;
   private StringBuilder stringBuilder = null;
 
-  public RestppPreparedStatement(RestppConnection restppConnection, String query, Integer debug) {
+  public RestppPreparedStatement(RestppConnection restppConnection,
+      String query, Integer debug, Integer timeout, Integer atomic) {
     super(restppConnection, query);
     this.query = query;
     this.debug = debug;
+    this.timeout = timeout;
+    this.atomic = atomic;
     edge_list = new ArrayList<String>();
     vertex_list = new ArrayList<String>();
   }
@@ -43,7 +48,7 @@ public class RestppPreparedStatement extends PreparedStatement {
   @Override public boolean execute() throws SQLException {
     // execute the query
     this.parser = new QueryParser((RestppConnection) getConnection(),
-        this.query, this.parameters, this.debug, this.timeout);
+        this.query, this.parameters, this.debug, this.timeout, this.atomic);
     this.query_type = parser.getQueryType();
 
     /**
@@ -100,7 +105,7 @@ public class RestppPreparedStatement extends PreparedStatement {
      * so we lower its debug level.
      */
     this.parser = new QueryParser((RestppConnection) getConnection(),
-        this.query, this.parameters, this.debug - 1, this.timeout);
+        this.query, this.parameters, this.debug - 1, this.timeout, this.atomic);
 
     if (this.parser.getQueryType() == QueryType.QUERY_TYPE_LOAD_JOB) {
       this.query_type = this.parser.getQueryType();
@@ -131,7 +136,7 @@ public class RestppPreparedStatement extends PreparedStatement {
      * so we lower its debug level.
      */
     this.parser = new QueryParser((RestppConnection) getConnection(),
-        sql, this.parameters, this.debug - 1, this.timeout);
+        sql, this.parameters, this.debug - 1, this.timeout, this.atomic);
 
     this.query_type = this.parser.getQueryType();
     this.eol = ((RestppConnection) getConnection()).getEol();

--- a/tools/etl/tg-jdbc-driver/tg-jdbc-restpp/src/main/java/com/tigergraph/jdbc/RestppStatement.java
+++ b/tools/etl/tg-jdbc-driver/tg-jdbc-restpp/src/main/java/com/tigergraph/jdbc/RestppStatement.java
@@ -18,14 +18,19 @@ import java.util.Map;
 public class RestppStatement extends Statement {
 
   private Integer debug = 0;
+  private Integer timeout = 0;
+  private Integer atomic = 0;
   private List<String> edge_list;
   private List<String> vertex_list;
   private QueryParser parser;
   private QueryType query_type;
 
-  public RestppStatement(RestppConnection restppConnection, Integer debug) {
+  public RestppStatement(RestppConnection restppConnection, Integer debug,
+      Integer timeout, Integer atomic) {
     super(restppConnection);
     this.debug = debug;
+    this.timeout = timeout;
+    this.atomic = atomic;
     edge_list = new ArrayList<String>();
     vertex_list = new ArrayList<String>();
   }
@@ -38,7 +43,7 @@ public class RestppStatement extends Statement {
   @Override public boolean execute(String query) throws SQLException {
     // execute the query
     this.parser = new QueryParser((RestppConnection) getConnection(), query,
-        null, this.debug, this.timeout);
+        null, this.debug, this.timeout, this.atomic);
     this.query_type = parser.getQueryType();
 
     RestppResponse response =
@@ -61,7 +66,7 @@ public class RestppStatement extends Statement {
 
   @Override public void addBatch(String sql) throws SQLException {
     this.parser = new QueryParser((RestppConnection) getConnection(), sql,
-        null, this.debug, this.timeout);
+        null, this.debug, this.timeout, this.atomic);
     String vertex_json = parser.getVertexJson();
     String edge_json = parser.getEdgeJson();
     if (vertex_json != "") {

--- a/tools/etl/tg-jdbc-driver/tg-jdbc-restpp/src/test/java/com/tigergraph/jdbc/QueryParserTest.java
+++ b/tools/etl/tg-jdbc-driver/tg-jdbc-restpp/src/test/java/com/tigergraph/jdbc/QueryParserTest.java
@@ -29,38 +29,38 @@ public class QueryParserTest extends TestCase {
     Map<Integer, Object> parameters = new HashMap<>(10);
     parameters.put(1, "3");
     StringBuilder sb = new StringBuilder();
-    QueryParser parser = new QueryParser(null, query, parameters, 0, 0);
+    QueryParser parser = new QueryParser(null, query, parameters, 0, 0, 0);
     sb.append(parser.getEndpoint()).append("\n");
 
     query = "get Page(filter=?)";
     parameters.clear();
     parameters.put(1, "page_id=1");
-    parser = new QueryParser(null, query, parameters, 0, 0);
+    parser = new QueryParser(null, query, parameters, 0, 0, 0);
     sb.append(parser.getEndpoint()).append("\n");
 
     query = "get edges(Page, ?)";
     parameters.clear();
     parameters.put(1, "2");
-    parser = new QueryParser(null, query, parameters, 0, 0);
+    parser = new QueryParser(null, query, parameters, 0, 0, 0);
     sb.append(parser.getEndpoint()).append("\n");
 
     query = "get edges(Page, ?, Linkto)";
     parameters.clear();
     parameters.put(1, "2");
-    parser = new QueryParser(null, query, parameters, 0, 0);
+    parser = new QueryParser(null, query, parameters, 0, 0, 0);
     sb.append(parser.getEndpoint()).append("\n");
 
     query = "get edges(Page, ?, Linkto, Page)";
     parameters.clear();
     parameters.put(1, "2");
-    parser = new QueryParser(null, query, parameters, 0, 0);
+    parser = new QueryParser(null, query, parameters, 0, 0, 0);
     sb.append(parser.getEndpoint()).append("\n");
 
     query = "get edge(Page, ?, Linkto, Page, ?)";
     parameters.clear();
     parameters.put(1, "2");
     parameters.put(2, "3");
-    parser = new QueryParser(null, query, parameters, 0, 0);
+    parser = new QueryParser(null, query, parameters, 0, 0, 0);
     sb.append(parser.getEndpoint()).append("\n");
 
     query = "run pageRank(maxChange=?, maxIteration=?, dampingFactor=?)";
@@ -68,11 +68,11 @@ public class QueryParserTest extends TestCase {
     parameters.put(1, "0.001");
     parameters.put(2, 10);
     parameters.put(3, "0.15");
-    parser = new QueryParser(null, query, parameters, 0, 0);
+    parser = new QueryParser(null, query, parameters, 0, 0, 0);
     sb.append(parser.getEndpoint()).append("\n");
 
     query = "INSERT INTO vertex Page(id, name, 'page rank', page_id, is_active) VALUES('1000', 'new page', 0.8, 1000, TRue)";
-    parser = new QueryParser(null, query, null, 0, 0);
+    parser = new QueryParser(null, query, null, 0, 0, 0);
     sb.append(parser.getVertexJson()).append("\n");
 
     query = "INSERT INTO vertex Page(id, name, 'page rank', page_id, is_active) VALUES(?, ?, ?, ?, ?)";
@@ -82,11 +82,11 @@ public class QueryParserTest extends TestCase {
     parameters.put(3, 0.8);
     parameters.put(4, 1000);
     parameters.put(5, Boolean.FALSE);
-    parser = new QueryParser(null, query, parameters, 0, 0);
+    parser = new QueryParser(null, query, parameters, 0, 0, 0);
     sb.append(parser.getVertexJson()).append("\n");
 
     query = "INSERT INTO edge Linkto(Page, Page, weight, is_active) VALUES('1000', '1001', 10.7, FaLse)";
-    parser = new QueryParser(null, query, null, 0, 0);
+    parser = new QueryParser(null, query, null, 0, 0, 1);
     sb.append(parser.getEdgeJson()).append("\n");
 
     query = "INSERT INTO edge Linkto(Page, Page, weight, is_active) VALUES(?, ?, ?, ?)";
@@ -95,19 +95,19 @@ public class QueryParserTest extends TestCase {
     parameters.put(2, "1001");
     parameters.put(3, 10.7);
     parameters.put(4, Boolean.TRUE);
-    parser = new QueryParser(null, query, parameters, 0, 0);
+    parser = new QueryParser(null, query, parameters, 0, 0, 0);
     sb.append(parser.getEdgeJson()).append("\n");
 
     query = "builtins stat_vertex_number(type=?)";
     parameters.clear();
     parameters.put(1, "Page");
-    parser = new QueryParser(null, query, parameters, 0, 0);
+    parser = new QueryParser(null, query, parameters, 0, 0, 0);
     sb.append(parser.getPayload()).append("\n");
 
     query = "builtins stat_edge_number(type=?)";
     parameters.clear();
     parameters.put(1, "Linkto");
-    parser = new QueryParser(null, query, parameters, 0, 0);
+    parser = new QueryParser(null, query, parameters, 0, 0, 0);
     sb.append(parser.getPayload()).append("\n");
 
     String formattedResult = sb.toString();


### PR DESCRIPTION
To specify query timeout and atomic post in a scalar script:
```
    "timeout" -> "60", // query timeout in seconds
    "atomic" -> "1", // 0 (default): nonatomic, 1: an atomic transaction
```

In Java:
```
    // Specify the query timeout (in seconds)
    properties.put("timeout", "60");

    // This request is an atomic transaction
    properties.put("atomic", "1");
```

