### PR TITLE
fix authentication with 3.x restpp

### DIFF
--- a/tools/etl/tg-jdbc-driver/tg-jdbc-restpp/src/main/java/com/tigergraph/jdbc/RestppConnection.java
+++ b/tools/etl/tg-jdbc-driver/tg-jdbc-restpp/src/main/java/com/tigergraph/jdbc/RestppConnection.java
@@ -297,8 +297,12 @@ public class RestppConnection extends Connection {
     }
     this.httpClient = builder.build();
 
-    if (this.token == null && this.username != null && this.password != null) {
+    if (this.token == null && this.username != null && this.password != null && this.graph != null ) {
       getToken();
+    } else if (this.token != null){
+      System.out.println(">>> Token exist, use current token");
+    } else {
+      System.out.println("!!! Skip authentication, please offer 'username','password' and 'graph' in properties");
     }
   }
 
@@ -359,10 +363,6 @@ public class RestppConnection extends Connection {
   private void getToken() throws SQLException {
     StringBuilder sb = new StringBuilder();
     sb.append("/gsqlserver/gsql/authtoken");
-    if (this.graph != null) {
-      sb.append("?graph=");
-      sb.append(this.graph);
-    }
     String url = "";
     try {
       if (this.secure)
@@ -372,9 +372,17 @@ public class RestppConnection extends Connection {
     } catch (MalformedURLException e) {
       throw new SQLException("Invalid server URL", e);
     }
-    HttpRequestBase request = new HttpGet(url);
+
+    sb.setLength(0);
+    sb.append("{\"graph\":\"");
+    sb.append(this.graph);
+    sb.append("\"}");
+    StringEntity payload =  new StringEntity(sb.toString(), "UTF-8");
+    payload.setContentType("application/json");
+    HttpPost request = new HttpPost(url);
     request.addHeader("Authorization", basicAuth);
     request.addHeader("Accept", ContentType.APPLICATION_JSON.toString());
+    request.setEntity(payload);
     /**
      * Response example:
      * {"error":false,"message":"","results":{"token":"5r6scnj83963gnfjqtvico1hf2hn394o"}}

--- a/tools/etl/tg-jdbc-driver/tg-jdbc-restpp/src/main/java/com/tigergraph/jdbc/RestppConnection.java
+++ b/tools/etl/tg-jdbc-driver/tg-jdbc-restpp/src/main/java/com/tigergraph/jdbc/RestppConnection.java
@@ -297,12 +297,18 @@ public class RestppConnection extends Connection {
     }
     this.httpClient = builder.build();
 
-    if (this.token == null && this.username != null && this.password != null && this.graph != null ) {
+    /**
+     * There're 3 types of connection
+     * 1) publicly accessible: both token and username are not specified, authentication needs to be turned off
+     * 2) token exist: ignore the username&password and use current token
+     * 3) get token: must specify username, password and graph with empty token
+     */
+    if (this.token == null && this.username != null && this.password != null && this.graph != null) {
       getToken();
     } else if (this.token != null){
-      System.out.println(">>> Token exist, use current token");
+      System.out.println(">>> Token exists, use current token");
     } else {
-      System.out.println("!!! Skip authentication, please offer 'username','password' and 'graph' in properties");
+      System.out.println(">>> Skip authentication, please offer 'username','password' and 'graph' in properties if authentication is needed");
     }
   }
 
@@ -377,7 +383,7 @@ public class RestppConnection extends Connection {
     sb.append("{\"graph\":\"");
     sb.append(this.graph);
     sb.append("\"}");
-    StringEntity payload =  new StringEntity(sb.toString(), "UTF-8");
+    StringEntity payload = new StringEntity(sb.toString(), "UTF-8");
     payload.setContentType("application/json");
     HttpPost request = new HttpPost(url);
     request.addHeader("Authorization", basicAuth);


### PR DESCRIPTION
- the jdbc driver now can't get token because of incompatibility with 3.x restpp api.
- this change fix this issue by add a JSON request body to fit current requirement (https://docs.tigergraph.com/tigergraph-server/current/api/built-in-endpoints#_request_a_token)
