### PR TITLE
Update vulnerabilities & add readme

### DIFF
--- a/tools/etl/tg-jdbc-driver/README.md
+++ b/tools/etl/tg-jdbc-driver/README.md
@@ -7,7 +7,8 @@ The TigerGraph JDBC Driver is a Type 4 driver, converting JDBC calls directly in
 | JDBC Version | TigerGraph Version | Java | Protocol | Query Result Format | New Features |
 | --- | --- | --- | --- | --- | --- |
 | 1.2.1 | 2.4.1~3.4 | 1.8 | Rest++ | ResultSet | Support interpreted queries and Spark partitioning |
-| 1.2.2 | 2.4.1~3.4 | 1.8 | Rest++ | ResultSet | Support interpreted queries and Spark partitioning |
+| 1.2.2 | 2.4.1~3.4 | 1.8 | Rest++ | ResultSet | Bug fix |
+| 1.2.3 | 2.4.1~3.4 | 1.8 | Rest++ | ResultSet | Bug fix |
 
 ## Dependency list
 | groupId | artifactId | version |
@@ -18,8 +19,6 @@ The TigerGraph JDBC Driver is a Type 4 driver, converting JDBC calls directly in
 | org.glassfish | javax.json | 1.1.4 |
 | org.junit.jupiter         | junit-jupiter-engine | 5.8.2 |
 | org.junit.vintage | junit-vintage-engine | 5.8.2 |
-| org.apache.logging.log4j | log4j-core | 2.17.2 |
-| org.apache.spark | spark-core_2.13 | 3.2.0 |
 
 ## Download from Maven Central Repository
 
@@ -481,7 +480,7 @@ Save any piece of the above script in a file (e.g., test.scala), and run it like
 ### To enable SSL with Spark
 Please add the following options to your scala script:
 ```
-    "trustStore" -> "trust.jks",
+    "trustStore" -> org.apache.spark.SparkFiles.get("trust.jks"),
     "trustStorePassword" -> "password",
     "trustStoreType" -> "JKS",
 ```

--- a/tools/etl/tg-jdbc-driver/README.md
+++ b/tools/etl/tg-jdbc-driver/README.md
@@ -6,20 +6,53 @@ The TigerGraph JDBC Driver is a Type 4 driver, converting JDBC calls directly in
 
 | JDBC Version | TigerGraph Version | Java | Protocol | Query Result Format | New Features |
 | --- | --- | --- | --- | --- | --- |
-| 1.0 | 2.2.4+ | 1.8 | Rest++ | JSON | Support builtin, compiled queries and loading jobs |
-| 1.1 | 2.4.1+ | 1.8 | Rest++ | ResultSet | Support tabular format and Spark |
-| 1.2 | 2.4.1+ | 1.8 | Rest++ | ResultSet | Support interpreted queries and Spark partitioning |
+| 1.2.1 | 2.4.1~3.4 | 1.8 | Rest++ | ResultSet | Support interpreted queries and Spark partitioning |
+| 1.2.2 | 2.4.1~3.4 | 1.8 | Rest++ | ResultSet | Support interpreted queries and Spark partitioning |
 
 ## Dependency list
 | groupId | artifactId | version |
 | --- | --- | --- |
-| org.apache.commons | commons-io | 1.3.2 |
-| org.apache.httpcomponents | httpclient | 4.5.8 |
+| org.apache.commons | commons-io | 2.7 |
+| org.apache.httpcomponents | httpclient | 4.5.13 |
 | org.json | json | 20180813 |
 | org.glassfish | javax.json | 1.1.4 |
-| junit | junit | 4.11 |
+| org.junit.jupiter         | junit-jupiter-engine | 5.8.2 |
+| org.junit.vintage | junit-vintage-engine | 5.8.2 |
+| org.apache.logging.log4j | log4j-core | 2.17.2 |
+| org.apache.spark | spark-core_2.13 | 3.2.0 |
+
+## Download from Maven Central Repository
+
+Tigergraph JDBC Driver can be found at [maven.org](https://search.maven.org/artifact/com.tigergraph/tigergraph-jdbc-driver).
+
+Please refer to [Versions compatibility](#versions-compatibility) to find the **suitable version**.
+
+* Use it in your java code:
+
+  * Apache Maven
+
+    ```xml
+    <dependency>
+      <groupId>com.tigergraph</groupId>
+      <artifactId>tigergraph-jdbc-driver</artifactId>
+      <version>{SUITABLE_VERSION}</version>
+    </dependency>
+    ```
+
+  * Gradle Groovy DSL
+
+    ```groovy
+    implementation 'com.tigergraph:tigergraph-jdbc-driver:{SUITABLE_VERSION}'
+    ```
+
+  Your build automation tool will download it autometically from maven central repository.
+
+* Use the jar file directly (e.g. Spark):
+
+    Go to [maven.org](https://search.maven.org/artifact/com.tigergraph/tigergraph-jdbc-driver) to get the jar file.
 
 ## Minimum viable snippet
+
 Parameters are passed as properties when creating a connection, such as username, password and graph name. Once REST++ authentication is enabled, username and password is mandatory. Graph name is required when MultiGraph is enabled.
 
 You may specify IP address and port as needed, and the port is the one used by GraphStudio.

--- a/tools/etl/tg-jdbc-driver/tg-jdbc-driver/pom.xml
+++ b/tools/etl/tg-jdbc-driver/tg-jdbc-driver/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.tigergraph</groupId>
     <artifactId>tigergraph-jdbc-driver</artifactId>
-    <version>1.2.2</version>
+    <version>1.2.3</version>
     <packaging>jar</packaging>
 
     <name>TigerGraph JDBC Driver Parent</name>
@@ -68,31 +68,15 @@
             <version>1.1.4</version>
         </dependency>
         <dependency>
+            <groupId>javax.json</groupId>
+            <artifactId>javax.json-api</artifactId>
+            <version>1.1.4</version>
+        </dependency>
+        <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
             <version>2.7</version>
             <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.spark</groupId>
-            <artifactId>spark-core_2.13</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>log4j</groupId>
-                    <artifactId>log4j</artifactId>
-                </exclusion>
-            </exclusions>
-            <version>3.2.0</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-1.2-api</artifactId>
-            <version>2.17.2</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-core</artifactId>
-            <version>2.17.2</version>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
@@ -167,6 +151,58 @@
                 <artifactId>maven-project-info-reports-plugin</artifactId>
                 <version>3.0.0</version>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>3.2.3</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <artifactSet>
+                                <excludes>
+                                    <exclude>commons-logging:commons-logging:jar:</exclude>
+                                    <exclude>org.apache.spark.unused.UnusedStubClass</exclude>
+                                </excludes>
+                            </artifactSet>
+                            <relocations>
+                                <relocation>
+                                    <pattern>org.apache.http</pattern>
+                                    <shadedPattern>org.shaded.apache.http</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>org.apache.commons.http</pattern>
+                                    <shadedPattern>org.shaded.apache.commons.http</shadedPattern>
+                                </relocation>
+                            </relocations>
+                            <filters>
+                                <filter>
+                                    <artifact>*:*</artifact>
+                                    <excludes>
+                                        <exclude>module-info.class</exclude>
+                                        <exclude>META-INF/*.SF</exclude>
+                                        <exclude>META-INF/*.DSA</exclude>
+                                        <exclude>META-INF/*.RSA</exclude>
+                                        <exclude>META-INF/MANIFEST.MF</exclude>
+                                        <exclude>META-INF/DEPENDENCIES</exclude>
+                                        <exclude>META-INF/NOTICE*</exclude>
+                                        <exclude>META-INF/ASL2.0</exclude>
+                                        <exclude>META-INF/LICENSE*</exclude>
+                                        <exclude>META-INF/maven/*/*/*</exclude>
+                                        <exclude>META-INF/services/*</exclude>
+                                    </excludes>
+                                </filter>
+                            </filters>
+                            <transformers>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
+                            </transformers>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 
@@ -224,67 +260,17 @@
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-javadoc-plugin</artifactId>
                         <version>3.3.2</version>
-                        <configuration>
-                            <additionalJOption>-Xdoclint:none</additionalJOption>
-                        </configuration>
                         <executions>
                             <execution>
                                 <id>attach-javadocs</id>
                                 <goals>
                                     <goal>jar</goal>
                                 </goals>
+                                <configuration>
+                                    <additionalJOption>-Xdoclint:none</additionalJOption>
+                                </configuration>
                             </execution>
                         </executions>
-                    </plugin>
-                    <!-- clean lifecycle, see https://maven.apache.org/ref/current/maven-core/lifecycles.html#clean_Lifecycle -->
-                    <plugin>
-                        <artifactId>maven-clean-plugin</artifactId>
-                        <version>3.1.0</version>
-                    </plugin>
-                    <!-- default lifecycle, jar packaging: see https://maven.apache.org/ref/current/maven-core/default-bindings.html#Plugin_bindings_for_jar_packaging -->
-                    <plugin>
-                        <artifactId>maven-resources-plugin</artifactId>
-                        <version>3.0.2</version>
-                    </plugin>
-                    <plugin>
-                        <artifactId>maven-compiler-plugin</artifactId>
-                        <version>3.8.0</version>
-                    </plugin>
-                    <plugin>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <version>2.22.1</version>
-                    </plugin>
-                    <plugin>
-                        <artifactId>maven-jar-plugin</artifactId>
-                        <version>3.0.2</version>
-                        <configuration>
-                            <archive>
-                                <manifestEntries>
-                                    <url>${project.organization.url}</url>
-                                    <Bundle-Vendor>${project.organization.name}</Bundle-Vendor>
-                                    <Bundle-ClassPath>"."</Bundle-ClassPath>
-                                    <Bundle-Version>${project.version}</Bundle-Version>
-                                    <Bundle-Name>TigerGraph JDBC driver</Bundle-Name>
-                                </manifestEntries>
-                            </archive>
-                        </configuration>
-                    </plugin>
-                    <plugin>
-                        <artifactId>maven-install-plugin</artifactId>
-                        <version>2.5.2</version>
-                    </plugin>
-                    <plugin>
-                        <artifactId>maven-deploy-plugin</artifactId>
-                        <version>2.8.2</version>
-                    </plugin>
-                    <!-- site lifecycle, see https://maven.apache.org/ref/current/maven-core/lifecycles.html#site_Lifecycle -->
-                    <plugin>
-                        <artifactId>maven-site-plugin</artifactId>
-                        <version>3.7.1</version>
-                    </plugin>
-                    <plugin>
-                        <artifactId>maven-project-info-reports-plugin</artifactId>
-                        <version>3.0.0</version>
                     </plugin>
                 </plugins>
             </build>

--- a/tools/etl/tg-jdbc-driver/tg-jdbc-driver/pom.xml
+++ b/tools/etl/tg-jdbc-driver/tg-jdbc-driver/pom.xml
@@ -1,163 +1,122 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-  <modelVersion>4.0.0</modelVersion>
+    <modelVersion>4.0.0</modelVersion>
 
-  <groupId>com.tigergraph</groupId>
-  <artifactId>tigergraph-jdbc-driver</artifactId>
-  <version>1.2.1</version>
-  <packaging>jar</packaging>
+    <groupId>com.tigergraph</groupId>
+    <artifactId>tigergraph-jdbc-driver</artifactId>
+    <version>1.2.2</version>
+    <packaging>jar</packaging>
 
-  <name>TigerGraph JDBC Driver Parent</name>
-  <description>This project is a type 4 jdbc driver which implemented the standard jdbc interface. It supports connectivity to tigergraph server and varieties of query types.</description>
-  <url>https://github.com/tigergraph/ecosys/tree/master/tools/etl/tg-jdbc-driver</url>
+    <name>TigerGraph JDBC Driver Parent</name>
+    <description>This project is a type 4 jdbc driver which implemented the standard jdbc interface. It supports connectivity to tigergraph server and varieties of query types.</description>
+    <url>https://github.com/tigergraph/ecosys/tree/master/tools/etl/tg-jdbc-driver</url>
 
-  <licenses>
-      <license>
-          <name>The Apache Software License, Version 2.0</name>
-          <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
-      </license>
-  </licenses>
+    <licenses>
+        <license>
+            <name>The Apache Software License, Version 2.0</name>
+            <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+        </license>
+    </licenses>
 
-  <developers>
-      <developer>
-          <name>Jon Herke</name>
-          <email>jon.herke@tigergraph.com</email>
-          <organization>TigerGraph Inc.</organization>
-          <organizationUrl>http://www.tigergraph.com</organizationUrl>
-      </developer>
-      <developer>
-          <name>Yong Tan</name>
-          <email>yong.tan@tigergraph.com</email>
-          <organization>TigerGraph Inc.</organization>
-          <organizationUrl>http://www.tigergraph.com</organizationUrl>
-      </developer>
-      <developer>
-          <name>Ping Xie</name>
-          <email>ping.xie@tigergraph.com</email>
-          <organization>TigerGraph Inc.</organization>
-          <organizationUrl>http://www.tigergraph.com</organizationUrl>
-      </developer>
-  </developers>
+    <developers>
+        <developer>
+            <name>Jon Herke</name>
+            <email>jon.herke@tigergraph.com</email>
+            <organization>TigerGraph Inc.</organization>
+            <organizationUrl>http://www.tigergraph.com</organizationUrl>
+        </developer>
+        <developer>
+            <name>Yong Tan</name>
+            <email>yong.tan@tigergraph.com</email>
+            <organization>TigerGraph Inc.</organization>
+            <organizationUrl>http://www.tigergraph.com</organizationUrl>
+        </developer>
+        <developer>
+            <name>Ping Xie</name>
+            <email>ping.xie@tigergraph.com</email>
+            <organization>TigerGraph Inc.</organization>
+            <organizationUrl>http://www.tigergraph.com</organizationUrl>
+        </developer>
+    </developers>
 
-  <scm>
-      <connection>scm:git:git://github.com:tigergraph/ecosys.git</connection>
-      <developerConnection>scm:git:ssh://github.com:tigergraph/ecosys.git</developerConnection>
-      <url>https://github.com/tigergraph/ecosys/tree/master/tools/etl/tg-jdbc-driver</url>
-  </scm>
+    <scm>
+        <connection>scm:git:git://github.com:tigergraph/ecosys.git</connection>
+        <developerConnection>scm:git:ssh://github.com:tigergraph/ecosys.git</developerConnection>
+        <url>https://github.com/tigergraph/ecosys/tree/master/tools/etl/tg-jdbc-driver</url>
+    </scm>
 
-  <properties>
-      <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-      <maven.compiler.source>1.8</maven.compiler.source>
-      <maven.compiler.target>1.8</maven.compiler.target>
-  </properties>
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+    </properties>
 
-  <dependencies>
-      <dependency>
-          <groupId>org.apache.httpcomponents</groupId>
-          <artifactId>httpclient</artifactId>
-          <version>4.5.8</version>
-      </dependency>
-      <dependency>
-          <groupId>org.json</groupId>
-          <artifactId>json</artifactId>
-          <version>20180813</version>
-      </dependency>
-      <dependency>
-          <groupId>org.glassfish</groupId>
-          <artifactId>javax.json</artifactId>
-          <version>1.1.4</version>
-      </dependency>
-      <dependency>
-          <groupId>commons-io</groupId>
-          <artifactId>commons-io</artifactId>
-          <version>1.3.2</version>
-          <scope>test</scope>
-      </dependency>
-      <dependency>
-          <groupId>org.apache.spark</groupId>
-          <artifactId>spark-core_2.13</artifactId>
-          <version>3.2.0</version>
-      </dependency>
-      <dependency>
-          <groupId>org.junit.jupiter</groupId>
-          <artifactId>junit-jupiter-engine</artifactId>
-          <version>5.8.2</version>
-          <scope>test</scope>
-      </dependency>
-          <dependency>
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <version>4.5.13</version>
+        </dependency>
+        <dependency>
+            <groupId>org.json</groupId>
+            <artifactId>json</artifactId>
+            <version>20180813</version>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish</groupId>
+            <artifactId>javax.json</artifactId>
+            <version>1.1.4</version>
+        </dependency>
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+            <version>2.7</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.spark</groupId>
+            <artifactId>spark-core_2.13</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>log4j</groupId>
+                    <artifactId>log4j</artifactId>
+                </exclusion>
+            </exclusions>
+            <version>3.2.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-1.2-api</artifactId>
+            <version>2.17.2</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
+            <version>2.17.2</version>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <version>5.8.2</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.junit.vintage</groupId>
             <artifactId>junit-vintage-engine</artifactId>
             <version>5.8.2</version>
             <scope>test</scope>
             <exclusions>
-              <exclusion>
-                <groupId>org.hamcrest</groupId>
-                <artifactId>hamcrest-core</artifactId>
-              </exclusion>
+                <exclusion>
+                    <groupId>org.hamcrest</groupId>
+                    <artifactId>hamcrest-core</artifactId>
+                </exclusion>
             </exclusions>
-          </dependency>
-  </dependencies>
+        </dependency>
+    </dependencies>
 
-  <distributionManagement>
-        <snapshotRepository>
-            <id>ossrh</id>
-            <url>https://s01.oss.sonatype.org/content/repositories/snapshots</url>
-        </snapshotRepository>
-  </distributionManagement>
-
-  <build>
+    <!-- default build plugins -->
+    <build>
         <plugins>
-            <plugin>
-                <groupId>org.sonatype.plugins</groupId>
-                <artifactId>nexus-staging-maven-plugin</artifactId>
-                <version>1.6.12</version>
-                <extensions>true</extensions>
-                <configuration>
-                    <serverId>ossrh</serverId>
-                    <nexusUrl>https://s01.oss.sonatype.org/</nexusUrl>
-                    <autoReleaseAfterClose>true</autoReleaseAfterClose>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-gpg-plugin</artifactId>
-                <version>1.5</version>
-                <executions>
-                    <execution>
-                        <id>sign-artifacts</id>
-                        <phase>verify</phase>
-                        <goals>
-                            <goal>sign</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-source-plugin</artifactId>
-                <version>2.2.1</version>
-                <executions>
-                    <execution>
-                        <id>attach-sources</id>
-                        <goals>
-                            <goal>jar-no-fork</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-javadoc-plugin</artifactId>
-                <version>2.9.1</version>
-                <executions>
-                    <execution>
-                        <id>attach-javadocs</id>
-                        <goals>
-                            <goal>jar</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
             <!-- clean lifecycle, see https://maven.apache.org/ref/current/maven-core/lifecycles.html#clean_Lifecycle -->
             <plugin>
                 <artifactId>maven-clean-plugin</artifactId>
@@ -209,5 +168,126 @@
                 <version>3.0.0</version>
             </plugin>
         </plugins>
-  </build>
+    </build>
+
+    <profiles>
+        <!-- profile for publishing -->
+        <profile>
+            <id>publish</id>
+            <distributionManagement>
+                <snapshotRepository>
+                    <id>ossrh</id>
+                    <url>https://s01.oss.sonatype.org/content/repositories/snapshots</url>
+                </snapshotRepository>
+            </distributionManagement>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.sonatype.plugins</groupId>
+                        <artifactId>nexus-staging-maven-plugin</artifactId>
+                        <version>1.6.12</version>
+                        <extensions>true</extensions>
+                        <configuration>
+                            <serverId>ossrh</serverId>
+                            <nexusUrl>https://s01.oss.sonatype.org/</nexusUrl>
+                            <autoReleaseAfterClose>true</autoReleaseAfterClose>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-gpg-plugin</artifactId>
+                        <version>1.5</version>
+                        <executions>
+                            <execution>
+                                <id>sign-artifacts</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>sign</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-source-plugin</artifactId>
+                        <version>3.2.1</version>
+                        <executions>
+                            <execution>
+                                <id>attach-sources</id>
+                                <goals>
+                                    <goal>jar-no-fork</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                        <version>3.3.2</version>
+                        <configuration>
+                            <additionalJOption>-Xdoclint:none</additionalJOption>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <id>attach-javadocs</id>
+                                <goals>
+                                    <goal>jar</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <!-- clean lifecycle, see https://maven.apache.org/ref/current/maven-core/lifecycles.html#clean_Lifecycle -->
+                    <plugin>
+                        <artifactId>maven-clean-plugin</artifactId>
+                        <version>3.1.0</version>
+                    </plugin>
+                    <!-- default lifecycle, jar packaging: see https://maven.apache.org/ref/current/maven-core/default-bindings.html#Plugin_bindings_for_jar_packaging -->
+                    <plugin>
+                        <artifactId>maven-resources-plugin</artifactId>
+                        <version>3.0.2</version>
+                    </plugin>
+                    <plugin>
+                        <artifactId>maven-compiler-plugin</artifactId>
+                        <version>3.8.0</version>
+                    </plugin>
+                    <plugin>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <version>2.22.1</version>
+                    </plugin>
+                    <plugin>
+                        <artifactId>maven-jar-plugin</artifactId>
+                        <version>3.0.2</version>
+                        <configuration>
+                            <archive>
+                                <manifestEntries>
+                                    <url>${project.organization.url}</url>
+                                    <Bundle-Vendor>${project.organization.name}</Bundle-Vendor>
+                                    <Bundle-ClassPath>"."</Bundle-ClassPath>
+                                    <Bundle-Version>${project.version}</Bundle-Version>
+                                    <Bundle-Name>TigerGraph JDBC driver</Bundle-Name>
+                                </manifestEntries>
+                            </archive>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <artifactId>maven-install-plugin</artifactId>
+                        <version>2.5.2</version>
+                    </plugin>
+                    <plugin>
+                        <artifactId>maven-deploy-plugin</artifactId>
+                        <version>2.8.2</version>
+                    </plugin>
+                    <!-- site lifecycle, see https://maven.apache.org/ref/current/maven-core/lifecycles.html#site_Lifecycle -->
+                    <plugin>
+                        <artifactId>maven-site-plugin</artifactId>
+                        <version>3.7.1</version>
+                    </plugin>
+                    <plugin>
+                        <artifactId>maven-project-info-reports-plugin</artifactId>
+                        <version>3.0.0</version>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/tools/etl/tg-jdbc-driver/tg-jdbc-driver/src/main/java/com/tigergraph/jdbc/restpp/RestppConnection.java
+++ b/tools/etl/tg-jdbc-driver/tg-jdbc-driver/src/main/java/com/tigergraph/jdbc/restpp/RestppConnection.java
@@ -22,7 +22,6 @@ import org.apache.http.impl.client.HttpClients;
 import org.apache.http.impl.conn.BasicHttpClientConnectionManager;
 import org.apache.http.ssl.SSLContextBuilder;
 import org.apache.http.ssl.SSLContexts;
-import org.apache.spark.SparkFiles;
 import org.json.JSONObject;
 
 import javax.net.ssl.SSLContext;
@@ -197,13 +196,6 @@ public class RestppConnection extends Connection {
         if (properties.containsKey("trustStore")) {
           hasSSLContext = Boolean.TRUE;
           String trustFilename = properties.getProperty("trustStore");
-          File tempFile = new File(trustFilename);
-          if (!tempFile.exists()) {
-            trustFilename = SparkFiles.get(trustFilename);
-            if (this.debug > 0) {
-              System.out.println(">>> SparkFiles: " + trustFilename);
-            }
-          }
           final KeyStore truststore = KeyStore.getInstance(trustStoreType);
           try (final InputStream in = new FileInputStream(new File(trustFilename))) {
             truststore.load(in, trustStorePassword.toCharArray());
@@ -214,13 +206,6 @@ public class RestppConnection extends Connection {
         if (properties.containsKey("keyStore")) {
           hasSSLContext = Boolean.TRUE;
           String keyFilename = properties.getProperty("keyStore");
-          File tempFile = new File(keyFilename);
-          if (!tempFile.exists()) {
-            keyFilename = SparkFiles.get(keyFilename);
-            if (this.debug > 0) {
-              System.out.println(">>> SparkFiles: " + keyFilename);
-            }
-          }
           final KeyStore keyStore = KeyStore.getInstance(keyStoreType);
           try (final InputStream in = new FileInputStream(new File(keyFilename))) {
             keyStore.load(in, keyStorePassword.toCharArray());

--- a/tools/etl/tg-jdbc-driver/tg-jdbc-examples/pom.xml
+++ b/tools/etl/tg-jdbc-driver/tg-jdbc-examples/pom.xml
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.tigergraph</groupId>
       <artifactId>tigergraph-jdbc-driver</artifactId>
-      <version>1.2.2</version>
+      <version>[1.2.1,)</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>

--- a/tools/etl/tg-jdbc-driver/tg-jdbc-examples/pom.xml
+++ b/tools/etl/tg-jdbc-driver/tg-jdbc-examples/pom.xml
@@ -16,13 +16,13 @@
   <dependencies>
     <dependency>
       <groupId>com.tigergraph</groupId>
-      <artifactId>tg-jdbc-driver</artifactId>
-      <version>${project.version}</version>
+      <artifactId>tigergraph-jdbc-driver</artifactId>
+      <version>1.2.2</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.11</version>
+      <version>4.13.1</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
- decouple jdbc from spark-core(get truststore files on Spark side)
  - uber jar size from 100MB to 1.6MB
  - eliminate conflicts from spark, hdfs, scala, etc.
  - remove log4j
- Update some vulnerabilities(**test passed**)
  - ~~Update log4j to 2.17.2~~
  - Update httpclient to 4.5.13
- Separate profiles for publishing(**test passed**)
  Add a profile `publish`, `sign` and `deploy` can only be triggered in this profile
- Add readme section "Download from Maven Central Repository"
