### PR TITLE
add dependency check plugin for jdbc

### DIFF
--- a/tools/etl/tg-jdbc-driver/README.md
+++ b/tools/etl/tg-jdbc-driver/README.md
@@ -9,6 +9,7 @@ The TigerGraph JDBC Driver is a Type 4 driver, converting JDBC calls directly in
 | 1.2.1 | 2.4.1~3.4 | 1.8 | Rest++ | ResultSet | Support interpreted queries and Spark partitioning |
 | 1.2.2 | 2.4.1~3.4 | 1.8 | Rest++ | ResultSet | Bug fix |
 | 1.2.3 | 2.4.1~3.4 | 1.8 | Rest++ | ResultSet | Bug fix |
+| 1.2.4 | 2.4.1~3.4 | 1.8 | Rest++ | ResultSet | Add vulnerability check plugin |
 
 ## Dependency list
 | groupId | artifactId | version |

--- a/tools/etl/tg-jdbc-driver/tg-jdbc-driver/pom.xml
+++ b/tools/etl/tg-jdbc-driver/tg-jdbc-driver/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.tigergraph</groupId>
     <artifactId>tigergraph-jdbc-driver</artifactId>
-    <version>1.2.3</version>
+    <version>1.2.4</version>
     <packaging>jar</packaging>
 
     <name>TigerGraph JDBC Driver Parent</name>
@@ -162,12 +162,6 @@
                             <goal>shade</goal>
                         </goals>
                         <configuration>
-                            <artifactSet>
-                                <excludes>
-                                    <exclude>commons-logging:commons-logging:jar:</exclude>
-                                    <exclude>org.apache.spark.unused.UnusedStubClass</exclude>
-                                </excludes>
-                            </artifactSet>
                             <relocations>
                                 <relocation>
                                     <pattern>org.apache.http</pattern>
@@ -200,6 +194,38 @@
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
                             </transformers>
                         </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <!--
+            Check vulnerabilities in dependency.
+            Usage:
+
+                mvn clean dependency-check:check
+
+            It will create a file named "dependency-check-report.html" in target/ folder.
+            Open it in browser you'll see the security vulnerability report.
+
+            However, due to the limitation of dependency checker, we have to
+            check the jar files which are actually included in this pom file.
+            To view them, run
+
+                mvn dependency:tree
+
+            Only the jars showing up both in above two command results indicating there's
+            vulnerability.
+
+            See details at https://nullbeans.com/how-to-identify-vulnerable-dependencies-in-a-maven-project/
+            -->
+            <plugin>
+                <groupId>org.owasp</groupId>
+                <artifactId>dependency-check-maven</artifactId>
+                <version>7.0.4</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
                     </execution>
                 </executions>
             </plugin>


### PR DESCRIPTION
- add dependency check plugin to find vulnerabilities.
- remove `<excludes>` which previously belong to spark-core