### PR TITLE
Add logging framework && bug fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 cloud/aws/aws_config
+tools/etl/tg-jdbc-driver/**/target
+tools/etl/tg-jdbc-driver/tg-jdbc-driver/dependency-reduced-pom.xml
 .DS_Store

--- a/tools/etl/tg-jdbc-driver/README.md
+++ b/tools/etl/tg-jdbc-driver/README.md
@@ -645,3 +645,12 @@ Sometimes it may complain that "Incompatible Jackson version: 2.x.x". You may ad
 
 ## Limitation of ResultSet
 The response packet size from the TigerGraph server should be less than 2GB, which is the largest response size supported by the TigerGraph Restful API.
+
+## Logging Configuration
+Tigergraph JDBC Driver supports 4 logging levels: 0 -> ERROR, 1 -> WARN, 2 -> INFO(Default) and 3 -> DEBUG.
+It supports two logging frameworks:
+- java.util.logging (JUL)
+  - To use logger, only need to pass in logging level by `properties.put("debug", "0|1|2|3");`, it will initialize with default logging handler and formater.
+  - To customize the JUL configuration, please write your own config file `logging.properties` and specify the JVM system property **explicitly**: `-Djava.util.logging.config.file=path_to_logging.properties`. Reference: [JUL Documentation](https://docs.oracle.com/javase/7/docs/api/java/util/logging/package-summary.html).
+- Simple Logging Facade for Java (SLF4J)
+  - To use SLF4J, specify the JVM system property: `-Dcom.tigergraph.jdbc.loggerImpl=slf4j` and put SLF4J binding in your classpath. Reference: [SLF4J Documentation](https://www.slf4j.org/docs.html).

--- a/tools/etl/tg-jdbc-driver/README.md
+++ b/tools/etl/tg-jdbc-driver/README.md
@@ -4,13 +4,14 @@ The TigerGraph JDBC Driver is a Type 4 driver, converting JDBC calls directly in
 
 ## Versions compatibility
 
-| JDBC Version | TigerGraph Version | Java | Protocol | Query Result Format | New Features |
-| --- | --- | --- | --- | --- | --- |
-| 1.2.1 | 2.4.1~3.4 | 1.8 | Rest++ | ResultSet | Support interpreted queries and Spark partitioning |
-| 1.2.2 | 2.4.1~3.4 | 1.8 | Rest++ | ResultSet | Bug fix |
-| 1.2.3 | 2.4.1~3.4 | 1.8 | Rest++ | ResultSet | Bug fix |
-| 1.2.4 | 2.4.1~3.4 | 1.8 | Rest++ | ResultSet | Add vulnerability check plugin |
-| 1.2.5 | 3.5+ | 1.8 | Rest++ | ResultSet | Fix restpp authentication incompatibility |
+| JDBC Version | TigerGraph Version | Java | New Features |
+| --- | --- | --- | --- |
+| 1.2.1 | 2.4.1~3.4 | 1.8 | Support interpreted queries and Spark partitioning |
+| 1.2.2 | 2.4.1~3.4 | 1.8 | Bug fix |
+| 1.2.3 | 2.4.1~3.4 | 1.8 | Bug fix |
+| 1.2.4 | 2.4.1~3.4 | 1.8 | Add vulnerability check plugin |
+| 1.2.5 | 3.5+ | 1.8 | Fix restpp authentication incompatibility |
+| 1.2.6 | 2.4.1+ | 1.8 | Bug fix && support version selection |
 
 ## Dependency list
 | groupId | artifactId | version |
@@ -22,6 +23,8 @@ The TigerGraph JDBC Driver is a Type 4 driver, converting JDBC calls directly in
 | org.junit.jupiter         | junit-jupiter-engine | 5.8.2 |
 | org.junit.vintage | junit-vintage-engine | 5.8.2 |
 | com.github.tomakehurst | wiremock | 2.27.2 |
+| org.apache.spark | spark-core_2.12 | 3.2.1 |
+| org.apache.maven | maven-artifact | 3.8.5 |
 
 ## Download from Maven Central Repository
 
@@ -59,6 +62,8 @@ Parameters are passed as properties when creating a connection, such as username
 
 You may specify IP address and port as needed, and the port is the one used by GraphStudio.
 
+You need to specify the version of tigergraph if it is under 3.5.
+
 For each ResultSet, there might be several tables with different tabular formats. **'isLast()' could be used to switch to the next table.**
 
 ```
@@ -66,6 +71,7 @@ Properties properties = new Properties();
 properties.put("username", "tigergraph");
 properties.put("password", "tigergraph");
 properties.put("graph", "gsql_demo");
+properties.put("version", "3.4");
 
 try {
   com.tigergraph.jdbc.Driver driver = new Driver();
@@ -483,7 +489,7 @@ Save any piece of the above script in a file (e.g., test.scala), and run it like
 ### To enable SSL with Spark
 Please add the following options to your scala script:
 ```
-    "trustStore" -> org.apache.spark.SparkFiles.get("trust.jks"),
+    "trustStore" -> "trust.jks",
     "trustStorePassword" -> "password",
     "trustStoreType" -> "JKS",
 ```

--- a/tools/etl/tg-jdbc-driver/tg-jdbc-driver/pom.xml
+++ b/tools/etl/tg-jdbc-driver/tg-jdbc-driver/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.tigergraph</groupId>
     <artifactId>tigergraph-jdbc-driver</artifactId>
-    <version>1.2.5</version>
+    <version>1.2.6</version>
     <packaging>jar</packaging>
 
     <name>TigerGraph JDBC Driver Parent</name>
@@ -106,6 +106,17 @@
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
             <version>1.7.36</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-artifact</artifactId>
+            <version>3.8.5</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.spark</groupId>
+            <artifactId>spark-core_2.12</artifactId>
+            <version>3.2.1</version>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
 

--- a/tools/etl/tg-jdbc-driver/tg-jdbc-driver/pom.xml
+++ b/tools/etl/tg-jdbc-driver/tg-jdbc-driver/pom.xml
@@ -102,6 +102,11 @@
             <version>2.27.2</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>1.7.36</version>
+        </dependency>
     </dependencies>
 
     <!-- default build plugins -->

--- a/tools/etl/tg-jdbc-driver/tg-jdbc-driver/src/main/java/com/tigergraph/jdbc/Driver.java
+++ b/tools/etl/tg-jdbc-driver/tg-jdbc-driver/src/main/java/com/tigergraph/jdbc/Driver.java
@@ -2,6 +2,7 @@ package com.tigergraph.jdbc;
 
 import com.tigergraph.jdbc.common.BaseDriver;
 import com.tigergraph.jdbc.restpp.RestppDriver;
+import com.tigergraph.jdbc.log.TGLoggerFactory;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -15,15 +16,25 @@ public class Driver extends BaseDriver {
   /**
    * Hash map of all available drivers.
    */
-  private final Map<String, Class> DRIVERS = new HashMap<String, Class>() {{
-    put(RestppDriver.JDBC_RESTPP_PREFIX, RestppDriver.class);
-  }};
+  private final Map<String, Class> DRIVERS = new HashMap<String, Class>() {
+    {
+      put(RestppDriver.JDBC_RESTPP_PREFIX, RestppDriver.class);
+    }
+  };
 
   public Driver() throws SQLException {
     super(null);
   }
 
-  @Override public Connection connect(String url, Properties info) throws SQLException {
+  @Override
+  public Connection connect(String url, Properties info) throws SQLException {
+    // Get logging level.
+    Integer logLevel = 2;
+    if (info.containsKey("debug")) {
+      logLevel = Integer.valueOf(info.getProperty("debug"));
+    }
+    TGLoggerFactory.initializeLogger(logLevel);
+
     return getDriver(url).connect(url, info);
   }
 
@@ -45,7 +56,7 @@ public class Driver extends BaseDriver {
           String prefix = pieces[2];
 
           // Search the driver hash map.
-          for(String key: DRIVERS.keySet()) {
+          for (String key : DRIVERS.keySet()) {
             if (prefix.matches(key)) {
               Constructor constructor = DRIVERS.get(key).getDeclaredConstructor();
               driver = (BaseDriver) constructor.newInstance();
@@ -64,4 +75,3 @@ public class Driver extends BaseDriver {
     return driver;
   }
 }
-

--- a/tools/etl/tg-jdbc-driver/tg-jdbc-driver/src/main/java/com/tigergraph/jdbc/common/DatabaseMetaData.java
+++ b/tools/etl/tg-jdbc-driver/tg-jdbc-driver/src/main/java/com/tigergraph/jdbc/common/DatabaseMetaData.java
@@ -11,14 +11,12 @@ public class DatabaseMetaData implements java.sql.DatabaseMetaData {
   private String driverName;
   private String driverVersion;
   private Connection connection;
-  private Integer debug = 0;
 
   /**
    * Default constructor.
    */
-  public DatabaseMetaData(Connection connection, Integer debug) {
+  public DatabaseMetaData(Connection connection) {
     this.connection = connection;
-    this.debug = debug;
 
     /**
      * Get driver name and version.

--- a/tools/etl/tg-jdbc-driver/tg-jdbc-driver/src/main/java/com/tigergraph/jdbc/log/JULAdapter.java
+++ b/tools/etl/tg-jdbc-driver/tg-jdbc-driver/src/main/java/com/tigergraph/jdbc/log/JULAdapter.java
@@ -1,0 +1,590 @@
+package com.tigergraph.jdbc.log;
+
+import java.util.logging.*;
+import org.slf4j.Marker;
+
+/**
+ *
+ * Wrapper of java.util.logging to log JDBC Driver query information
+ * Only 4 levels are included: ERROR, WARN, INFO and DEBUG
+ * This class implements a part of SLF4J Logger interface
+ * LocationAwareLogger, Marker and Lazy Evaluation are not supported
+ *
+ * 
+ * mapping from TGLogger to java.util.logging:
+ * ERROR -> SEVERE
+ * WARN -> WARNING
+ * INFO -> INFO
+ * DEBUG -> FINE
+ */
+
+public class JULAdapter implements org.slf4j.Logger {
+
+    private Logger logger;
+
+    public JULAdapter(String name) {
+        logger = Logger.getLogger(name);
+    }
+
+    /**
+     * Is the logger instance enabled for the DEBUG level?
+     *
+     * @return True if this Logger is enabled for the DEBUG level,
+     *         false otherwise.
+     */
+    public boolean isDebugEnabled() {
+        return logger.isLoggable(Level.FINE);
+    }
+
+    /**
+     * Log a message at the DEBUG level.
+     *
+     * @param msg the message string to be logged
+     */
+    public void debug(String msg) {
+        logger.fine(msg);
+    }
+
+    /**
+     * Log a message at the DEBUG level according to the specified format
+     * and argument.
+     * <p/>
+     * <p>
+     * This form avoids superfluous object creation when the logger
+     * is disabled for the DEBUG level.
+     * </p>
+     *
+     * @param format the format string
+     * @param arg    the argument
+     */
+    public void debug(String format, Object arg) {
+        logger.log(Level.FINE, Util.formatConverter(format), arg);
+    }
+
+    /**
+     * Log a message at the DEBUG level according to the specified format
+     * and arguments.
+     * <p/>
+     * <p>
+     * This form avoids superfluous object creation when the logger
+     * is disabled for the DEBUG level.
+     * </p>
+     *
+     * @param format the format string
+     * @param arg1   the first argument
+     * @param arg2   the second argument
+     */
+    public void debug(String format, Object arg1, Object arg2) {
+        logger.log(Level.FINE, Util.formatConverter(format), new Object[] { arg1, arg2 });
+    }
+
+    /**
+     * Log a message at the DEBUG level according to the specified format
+     * and arguments.
+     * <p/>
+     * <p>
+     * This form avoids superfluous string concatenation when the logger
+     * is disabled for the DEBUG level. However, this variant incurs the hidden
+     * (and relatively small) cost of creating an <code>Object[]</code> before
+     * invoking the method,
+     * even if this logger is disabled for DEBUG. The variants taking
+     * {@link #debug(String, Object) one} and {@link #debug(String, Object, Object)
+     * two}
+     * arguments exist solely in order to avoid this hidden cost.
+     * </p>
+     *
+     * @param format    the format string
+     * @param arguments a list of 3 or more arguments
+     */
+    public void debug(String format, Object... arguments) {
+        logger.log(Level.FINE, Util.formatConverter(format), arguments);
+    }
+
+    /**
+     * Log an exception (throwable) at the DEBUG level with an
+     * accompanying message.
+     *
+     * @param msg the message accompanying the exception
+     * @param t   the exception (throwable) to log
+     */
+    public void debug(String msg, Throwable t) {
+        logger.log(Level.FINE, msg, t);
+    }
+
+    /**
+     * Is the logger instance enabled for the INFO level?
+     *
+     * @return True if this Logger is enabled for the INFO level,
+     *         false otherwise.
+     */
+    public boolean isInfoEnabled() {
+        return logger.isLoggable(Level.INFO);
+    }
+
+    /**
+     * Log a message at the INFO level.
+     *
+     * @param msg the message string to be logged
+     */
+    public void info(String msg) {
+        logger.info(msg);
+    }
+
+    /**
+     * Log a message at the INFO level according to the specified format
+     * and argument.
+     * <p/>
+     * <p>
+     * This form avoids superfluous object creation when the logger
+     * is disabled for the INFO level.
+     * </p>
+     *
+     * @param format the format string
+     * @param arg    the argument
+     */
+    public void info(String format, Object arg) {
+        logger.log(Level.INFO, Util.formatConverter(format), arg);
+    }
+
+    /**
+     * Log a message at the INFO level according to the specified format
+     * and arguments.
+     * <p/>
+     * <p>
+     * This form avoids superfluous object creation when the logger
+     * is disabled for the INFO level.
+     * </p>
+     *
+     * @param format the format string
+     * @param arg1   the first argument
+     * @param arg2   the second argument
+     */
+    public void info(String format, Object arg1, Object arg2) {
+        logger.log(Level.INFO, Util.formatConverter(format), new Object[] { arg1, arg2 });
+    }
+
+    /**
+     * Log a message at the INFO level according to the specified format
+     * and arguments.
+     * <p/>
+     * <p>
+     * This form avoids superfluous string concatenation when the logger
+     * is disabled for the INFO level. However, this variant incurs the hidden
+     * (and relatively small) cost of creating an <code>Object[]</code> before
+     * invoking the method,
+     * even if this logger is disabled for INFO. The variants taking
+     * {@link #info(String, Object) one} and {@link #info(String, Object, Object)
+     * two}
+     * arguments exist solely in order to avoid this hidden cost.
+     * </p>
+     *
+     * @param format    the format string
+     * @param arguments a list of 3 or more arguments
+     */
+    public void info(String format, Object... arguments) {
+        logger.log(Level.INFO, Util.formatConverter(format), arguments);
+    }
+
+    /**
+     * Log an exception (throwable) at the INFO level with an
+     * accompanying message.
+     *
+     * @param msg the message accompanying the exception
+     * @param t   the exception (throwable) to log
+     */
+    public void info(String msg, Throwable t) {
+        logger.log(Level.INFO, msg, t);
+    }
+
+    /**
+     * Is the logger instance enabled for the WARN level?
+     *
+     * @return True if this Logger is enabled for the WARN level,
+     *         false otherwise.
+     */
+    public boolean isWarnEnabled() {
+        return logger.isLoggable(Level.WARNING);
+    }
+
+    /**
+     * Log a message at the WARN level.
+     *
+     * @param msg the message string to be logged
+     */
+    public void warn(String msg) {
+        logger.warning(msg);
+    }
+
+    /**
+     * Log a message at the WARN level according to the specified format
+     * and argument.
+     * <p/>
+     * <p>
+     * This form avoids superfluous object creation when the logger
+     * is disabled for the WARN level.
+     * </p>
+     *
+     * @param format the format string
+     * @param arg    the argument
+     */
+    public void warn(String format, Object arg) {
+        logger.log(Level.WARNING, Util.formatConverter(format), arg);
+    }
+
+    /**
+     * Log a message at the WARN level according to the specified format
+     * and arguments.
+     * <p/>
+     * <p>
+     * This form avoids superfluous string concatenation when the logger
+     * is disabled for the WARN level. However, this variant incurs the hidden
+     * (and relatively small) cost of creating an <code>Object[]</code> before
+     * invoking the method,
+     * even if this logger is disabled for WARN. The variants taking
+     * {@link #warn(String, Object) one} and {@link #warn(String, Object, Object)
+     * two}
+     * arguments exist solely in order to avoid this hidden cost.
+     * </p>
+     *
+     * @param format    the format string
+     * @param arguments a list of 3 or more arguments
+     */
+    public void warn(String format, Object... arguments) {
+        logger.log(Level.WARNING, Util.formatConverter(format), arguments);
+    }
+
+    /**
+     * Log a message at the WARN level according to the specified format
+     * and arguments.
+     * <p/>
+     * <p>
+     * This form avoids superfluous object creation when the logger
+     * is disabled for the WARN level.
+     * </p>
+     *
+     * @param format the format string
+     * @param arg1   the first argument
+     * @param arg2   the second argument
+     */
+    public void warn(String format, Object arg1, Object arg2) {
+        logger.log(Level.WARNING, Util.formatConverter(format), new Object[] { arg1, arg2 });
+    }
+
+    /**
+     * Log an exception (throwable) at the WARN level with an
+     * accompanying message.
+     *
+     * @param msg the message accompanying the exception
+     * @param t   the exception (throwable) to log
+     */
+    public void warn(String msg, Throwable t) {
+        logger.log(Level.WARNING, msg, t);
+    }
+
+    /**
+     * Is the logger instance enabled for the ERROR level?
+     *
+     * @return True if this Logger is enabled for the ERROR level,
+     *         false otherwise.
+     */
+    public boolean isErrorEnabled() {
+        return logger.isLoggable(Level.SEVERE);
+    }
+
+    /**
+     * Log a message at the ERROR level.
+     *
+     * @param msg the message string to be logged
+     */
+    public void error(String msg) {
+        logger.severe(msg);
+    }
+
+    /**
+     * Log a message at the ERROR level according to the specified format
+     * and argument.
+     * <p/>
+     * <p>
+     * This form avoids superfluous object creation when the logger
+     * is disabled for the ERROR level.
+     * </p>
+     *
+     * @param format the format string
+     * @param arg    the argument
+     */
+    public void error(String format, Object arg) {
+        logger.log(Level.SEVERE, Util.formatConverter(format), arg);
+    }
+
+    /**
+     * Log a message at the ERROR level according to the specified format
+     * and arguments.
+     * <p/>
+     * <p>
+     * This form avoids superfluous object creation when the logger
+     * is disabled for the ERROR level.
+     * </p>
+     *
+     * @param format the format string
+     * @param arg1   the first argument
+     * @param arg2   the second argument
+     */
+    public void error(String format, Object arg1, Object arg2) {
+        logger.log(Level.SEVERE, Util.formatConverter(format), new Object[] { arg1, arg2 });
+    }
+
+    /**
+     * Log a message at the ERROR level according to the specified format
+     * and arguments.
+     * <p/>
+     * <p>
+     * This form avoids superfluous string concatenation when the logger
+     * is disabled for the ERROR level. However, this variant incurs the hidden
+     * (and relatively small) cost of creating an <code>Object[]</code> before
+     * invoking the method,
+     * even if this logger is disabled for ERROR. The variants taking
+     * {@link #error(String, Object) one} and {@link #error(String, Object, Object)
+     * two}
+     * arguments exist solely in order to avoid this hidden cost.
+     * </p>
+     *
+     * @param format    the format string
+     * @param arguments a list of 3 or more arguments
+     */
+    public void error(String format, Object... arguments) {
+        logger.log(Level.SEVERE, Util.formatConverter(format), arguments);
+    }
+
+    /**
+     * Log an exception (throwable) at the ERROR level with an
+     * accompanying message.
+     *
+     * @param msg the message accompanying the exception
+     * @param t   the exception (throwable) to log
+     */
+    public void error(String msg, Throwable t) {
+        logger.log(Level.SEVERE, msg, t);
+    }
+
+    @Override
+    public String getName() {
+        // TODO Auto-generated method stub
+        return null;
+    }
+
+    @Override
+    public boolean isTraceEnabled() {
+        // TODO Auto-generated method stub
+        return false;
+    }
+
+    @Override
+    public void trace(String msg) {
+        // TODO Auto-generated method stub
+
+    }
+
+    @Override
+    public void trace(String format, Object arg) {
+        // TODO Auto-generated method stub
+
+    }
+
+    @Override
+    public void trace(String format, Object arg1, Object arg2) {
+        // TODO Auto-generated method stub
+
+    }
+
+    @Override
+    public void trace(String format, Object... arguments) {
+        // TODO Auto-generated method stub
+
+    }
+
+    @Override
+    public void trace(String msg, Throwable t) {
+        // TODO Auto-generated method stub
+
+    }
+
+    @Override
+    public boolean isTraceEnabled(Marker marker) {
+        // TODO Auto-generated method stub
+        return false;
+    }
+
+    @Override
+    public void trace(Marker marker, String msg) {
+        // TODO Auto-generated method stub
+
+    }
+
+    @Override
+    public void trace(Marker marker, String format, Object arg) {
+        // TODO Auto-generated method stub
+
+    }
+
+    @Override
+    public void trace(Marker marker, String format, Object arg1, Object arg2) {
+        // TODO Auto-generated method stub
+
+    }
+
+    @Override
+    public void trace(Marker marker, String format, Object... argArray) {
+        // TODO Auto-generated method stub
+
+    }
+
+    @Override
+    public void trace(Marker marker, String msg, Throwable t) {
+        // TODO Auto-generated method stub
+
+    }
+
+    @Override
+    public boolean isDebugEnabled(Marker marker) {
+        // TODO Auto-generated method stub
+        return false;
+    }
+
+    @Override
+    public void debug(Marker marker, String msg) {
+        // TODO Auto-generated method stub
+
+    }
+
+    @Override
+    public void debug(Marker marker, String format, Object arg) {
+        // TODO Auto-generated method stub
+
+    }
+
+    @Override
+    public void debug(Marker marker, String format, Object arg1, Object arg2) {
+        // TODO Auto-generated method stub
+
+    }
+
+    @Override
+    public void debug(Marker marker, String format, Object... arguments) {
+        // TODO Auto-generated method stub
+
+    }
+
+    @Override
+    public void debug(Marker marker, String msg, Throwable t) {
+        // TODO Auto-generated method stub
+
+    }
+
+    @Override
+    public boolean isInfoEnabled(Marker marker) {
+        // TODO Auto-generated method stub
+        return false;
+    }
+
+    @Override
+    public void info(Marker marker, String msg) {
+        // TODO Auto-generated method stub
+
+    }
+
+    @Override
+    public void info(Marker marker, String format, Object arg) {
+        // TODO Auto-generated method stub
+
+    }
+
+    @Override
+    public void info(Marker marker, String format, Object arg1, Object arg2) {
+        // TODO Auto-generated method stub
+
+    }
+
+    @Override
+    public void info(Marker marker, String format, Object... arguments) {
+        // TODO Auto-generated method stub
+
+    }
+
+    @Override
+    public void info(Marker marker, String msg, Throwable t) {
+        // TODO Auto-generated method stub
+
+    }
+
+    @Override
+    public boolean isWarnEnabled(Marker marker) {
+        // TODO Auto-generated method stub
+        return false;
+    }
+
+    @Override
+    public void warn(Marker marker, String msg) {
+        // TODO Auto-generated method stub
+
+    }
+
+    @Override
+    public void warn(Marker marker, String format, Object arg) {
+        // TODO Auto-generated method stub
+
+    }
+
+    @Override
+    public void warn(Marker marker, String format, Object arg1, Object arg2) {
+        // TODO Auto-generated method stub
+
+    }
+
+    @Override
+    public void warn(Marker marker, String format, Object... arguments) {
+        // TODO Auto-generated method stub
+
+    }
+
+    @Override
+    public void warn(Marker marker, String msg, Throwable t) {
+        // TODO Auto-generated method stub
+
+    }
+
+    @Override
+    public boolean isErrorEnabled(Marker marker) {
+        // TODO Auto-generated method stub
+        return false;
+    }
+
+    @Override
+    public void error(Marker marker, String msg) {
+        // TODO Auto-generated method stub
+
+    }
+
+    @Override
+    public void error(Marker marker, String format, Object arg) {
+        // TODO Auto-generated method stub
+
+    }
+
+    @Override
+    public void error(Marker marker, String format, Object arg1, Object arg2) {
+        // TODO Auto-generated method stub
+
+    }
+
+    @Override
+    public void error(Marker marker, String format, Object... arguments) {
+        // TODO Auto-generated method stub
+
+    }
+
+    @Override
+    public void error(Marker marker, String msg, Throwable t) {
+        // TODO Auto-generated method stub
+
+    }
+}

--- a/tools/etl/tg-jdbc-driver/tg-jdbc-driver/src/main/java/com/tigergraph/jdbc/log/JULFormatter.java
+++ b/tools/etl/tg-jdbc-driver/tg-jdbc-driver/src/main/java/com/tigergraph/jdbc/log/JULFormatter.java
@@ -1,0 +1,41 @@
+package com.tigergraph.jdbc.log;
+
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.TimeZone;
+import java.util.logging.Formatter;
+import java.util.logging.Handler;
+import java.util.logging.LogRecord;
+
+/**
+ * Default formatter for JUL, e.g. 05-09 02:37:53 [SEVERE] Default JUL Format
+ */
+
+public class JULFormatter extends Formatter{
+    private static final DateFormat df = new SimpleDateFormat("MM-dd HH:mm:ss");
+
+    static {
+      df.setTimeZone(TimeZone.getTimeZone("UTC"));
+    }
+
+    @Override
+    public String format(LogRecord record) {
+      StringBuilder builder = new StringBuilder(256);
+      builder.append(df.format(new Date(record.getMillis()))).append(" [");
+      builder.append(record.getLevel()).append("] ");
+      builder.append(formatMessage(record));
+      builder.append("\n");
+      return builder.toString();
+    }
+  
+    @Override
+    public String getHead(Handler h) {
+      return super.getHead(h);
+    }
+  
+    @Override
+    public String getTail(Handler h) {
+      return super.getTail(h);
+    }
+}

--- a/tools/etl/tg-jdbc-driver/tg-jdbc-driver/src/main/java/com/tigergraph/jdbc/log/TGLoggerFactory.java
+++ b/tools/etl/tg-jdbc-driver/tg-jdbc-driver/src/main/java/com/tigergraph/jdbc/log/TGLoggerFactory.java
@@ -1,0 +1,99 @@
+package com.tigergraph.jdbc.log;
+
+import org.slf4j.LoggerFactory;
+import org.slf4j.Logger;
+import java.util.logging.Level;
+import java.util.logging.ConsoleHandler;
+
+/**
+ * create logger according to specified logger implementation
+ */
+
+public class TGLoggerFactory {
+
+    private static final Level[] levelMapping = new Level[] { Level.SEVERE, Level.WARNING, Level.INFO, Level.FINE };
+
+    private static enum LoggerType {
+        JUL_DEFAULT, JUL_WITH_CONFIG, SLF4J
+    }
+
+    private static final String DEFAULT_ROOT_LOGGER_NAME = "com.tigergraph.jdbc";
+
+    private static LoggerType loggerType;
+
+    /**
+     * @param clazz the returned logger will be named after clazz
+     * @return An instance of JavaLogger of SLF4JLogger
+     */
+    public static Logger getLogger(Class<?> clazz) {
+        switch (loggerType) {
+            case SLF4J:
+                return LoggerFactory.getLogger(clazz);
+            case JUL_DEFAULT:
+            case JUL_WITH_CONFIG:
+            default:
+                return new JULAdapter(clazz.getName());
+        }
+    }
+
+    /**
+     * Initialize parent logger `com.tigergraph.jdbc` with default settings if
+     * 
+     * 
+     * NOP if JUL_WITH_CONFIG or SLF4J
+     * 
+     * @param level debug level passed in by properties
+     */
+    public static void initializeLogger(Integer level) {
+        loggerType = setLoggerType();
+        switch (loggerType) {
+            case JUL_WITH_CONFIG:
+            case SLF4J:
+                return;
+            case JUL_DEFAULT:
+            default:
+                java.util.logging.Logger jdbcRootLogger = java.util.logging.Logger.getLogger(DEFAULT_ROOT_LOGGER_NAME);
+                // Do not forward any log messages to the logger parent handlers.
+                jdbcRootLogger.setUseParentHandlers(false);
+                jdbcRootLogger.setLevel(Level.ALL);
+                // Only need 1 handler when connecting multiple times.
+                if (jdbcRootLogger.getHandlers().length == 0) {
+                    jdbcRootLogger.addHandler(new ConsoleHandler());
+                }
+                if (level < 0 || level > 3) {
+                    jdbcRootLogger.getHandlers()[0].setLevel(Level.INFO);
+                    jdbcRootLogger.log(Level.WARNING,
+                            "Debug Level should between 0 and 3 but got {0}. Use 2(INFO) by default",
+                            level);
+                } else {
+                    jdbcRootLogger.getHandlers()[0].setLevel(levelMapping[level]);
+                }
+                jdbcRootLogger.getHandlers()[0].setFormatter(new JULFormatter());
+        }
+    }
+
+    /**
+     * Read from system properties to determine the logger type
+     * 
+     * @return one of JUL_DEFAULT, JUL_WITH_CONFIG, SLF4J
+     */
+    private static LoggerType setLoggerType() {
+        if (Util.getSysProperty("com.tigergraph.jdbc.loggerImpl") != null
+                && Util.getSysProperty("com.tigergraph.jdbc.loggerImpl").equalsIgnoreCase("slf4j")) {
+            return LoggerType.SLF4J;
+        } else if (Util.getSysProperty("java.util.logging.config.file") != null) {
+            return LoggerType.JUL_WITH_CONFIG;
+        } else {
+            return LoggerType.JUL_DEFAULT;
+        }
+    }
+
+    /**
+     * For testing
+     * 
+     * @return
+     */
+    public static String getLoggerType() {
+        return loggerType.name();
+    }
+}

--- a/tools/etl/tg-jdbc-driver/tg-jdbc-driver/src/main/java/com/tigergraph/jdbc/log/Util.java
+++ b/tools/etl/tg-jdbc-driver/tg-jdbc-driver/src/main/java/com/tigergraph/jdbc/log/Util.java
@@ -1,0 +1,36 @@
+package com.tigergraph.jdbc.log;
+
+public class Util {
+
+    /**
+     * Convert slf4j message format to java.util.logging style
+     * "hello {}, this is {}" -> "hello {0}, this is {1}"
+     * 
+     * @param format
+     * @return
+     */
+    public static String formatConverter(String format) {
+        StringBuilder sb = new StringBuilder();
+        int argCount = 0;
+        for (int i = 0; i < format.length(); i++) {
+            if (i < format.length() - 1 && format.charAt(i) == '{' && format.charAt(i + 1) == '}') {
+                sb.append(String.format("{%d}", argCount));
+                argCount++;
+                i++;
+            } else {
+                sb.append(format.charAt(i));
+            }
+        }
+        return sb.toString();
+    }
+
+    public static final String getSysProperty(String key) {
+        try {
+            String val = System.getProperty(key);
+            return val;
+        } catch (SecurityException e) {
+            System.out.printf(">>> Unable to get %s: %s, assume a null value.\n", key, e.getMessage());
+            return null;
+        }
+    }
+}

--- a/tools/etl/tg-jdbc-driver/tg-jdbc-driver/src/main/java/com/tigergraph/jdbc/restpp/driver/QueryParser.java
+++ b/tools/etl/tg-jdbc-driver/tg-jdbc-driver/src/main/java/com/tigergraph/jdbc/restpp/driver/QueryParser.java
@@ -807,6 +807,13 @@ public class QueryParser {
       sb.append(urlEncode(sep));
       sb.append("&eol=");
       sb.append(urlEncode(eol));
+      if (this.atomic > 0) {
+        sb.append("&atomic_post=true");
+      }
+    } else if (this.query_type == QueryType.QUERY_TYPE_GRAPH) {
+      if (this.atomic > 0) {
+        sb.append("?atomic_post=true");
+      }
     }
 
     String url = "";

--- a/tools/etl/tg-jdbc-driver/tg-jdbc-driver/src/main/java/com/tigergraph/jdbc/restpp/driver/RestppResponse.java
+++ b/tools/etl/tg-jdbc-driver/tg-jdbc-driver/src/main/java/com/tigergraph/jdbc/restpp/driver/RestppResponse.java
@@ -1,11 +1,13 @@
 package com.tigergraph.jdbc.restpp.driver;
 
+import com.tigergraph.jdbc.log.TGLoggerFactory;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpResponse;
 import org.apache.http.HttpStatus;
 import org.apache.http.util.EntityUtils;
 import org.json.JSONArray;
 import org.json.JSONObject;
+import org.slf4j.Logger;
 
 import java.io.IOException;
 import java.sql.SQLException;
@@ -16,12 +18,14 @@ import java.util.List;
  * Parse response from TigerGraph server, and return a JSONObject List.
  */
 public class RestppResponse {
+
+  private static final Logger logger = TGLoggerFactory.getLogger(RestppResponse.class);
+
   private Integer code;
   private Boolean is_error;
   private String errCode;
   private String errMsg;
   private List<JSONObject> results;
-  private Integer debug = 0;
 
   /**
    * For unit test only.
@@ -31,8 +35,7 @@ public class RestppResponse {
     this.code = HttpStatus.SC_OK;
   }
 
-  public RestppResponse(HttpResponse response, Boolean panic_on_fail,
-      Integer debug) throws SQLException {
+  public RestppResponse(HttpResponse response, Boolean panic_on_fail) throws SQLException {
     this.results = new ArrayList<>();
 
     if (response.getStatusLine() == null) {
@@ -43,7 +46,6 @@ public class RestppResponse {
       }
     }
 
-    this.debug = debug;
     this.code = response.getStatusLine().getStatusCode();
 
     if (this.code != HttpStatus.SC_OK) {
@@ -65,9 +67,6 @@ public class RestppResponse {
 
     try {
       String content = EntityUtils.toString(entity);
-      if (debug > 0) {
-        System.out.println(">>> Response: " + content);
-      }
       parse(content);
     } catch (IOException e) {
       throw new SQLException(e);
@@ -87,10 +86,10 @@ public class RestppResponse {
     } else {
       Object value = obj.get("results");
       if (value instanceof JSONObject) {
-        this.results.add((JSONObject)value);
+        this.results.add((JSONObject) value);
       } else if (value instanceof JSONArray) {
-        JSONArray resultList = (JSONArray)value;
-        for(int i = 0; i < resultList.length(); i++){
+        JSONArray resultList = (JSONArray) value;
+        for (int i = 0; i < resultList.length(); i++) {
           this.results.add(resultList.getJSONObject(i));
         }
       }
@@ -122,7 +121,7 @@ public class RestppResponse {
    */
   public String toString() {
     StringBuilder sb = new StringBuilder();
-    for(int i = 0; i < this.results.size(); i++){
+    for (int i = 0; i < this.results.size(); i++) {
       sb.append(String.valueOf(this.results.get(i)));
       sb.append(System.lineSeparator());
     }

--- a/tools/etl/tg-jdbc-driver/tg-jdbc-driver/src/test/java/com/tigergraph/jdbc/QueryParserTest.java
+++ b/tools/etl/tg-jdbc-driver/tg-jdbc-driver/src/test/java/com/tigergraph/jdbc/QueryParserTest.java
@@ -22,38 +22,38 @@ public class QueryParserTest extends TestCase {
     Map<Integer, Object> parameters = new HashMap<>(10);
     parameters.put(1, "3");
     StringBuilder sb = new StringBuilder();
-    QueryParser parser = new QueryParser(null, query, parameters, 0, 0, 0);
+    QueryParser parser = new QueryParser(null, query, parameters, 0, 0);
     sb.append(parser.getEndpoint()).append(System.lineSeparator());
 
     query = "get Page(filter=?)";
     parameters.clear();
     parameters.put(1, "page_id=1");
-    parser = new QueryParser(null, query, parameters, 0, 0, 0);
+    parser = new QueryParser(null, query, parameters, 0, 0);
     sb.append(parser.getEndpoint()).append(System.lineSeparator());
 
     query = "get edges(Page, ?)";
     parameters.clear();
     parameters.put(1, "2");
-    parser = new QueryParser(null, query, parameters, 0, 0, 0);
+    parser = new QueryParser(null, query, parameters, 0, 0);
     sb.append(parser.getEndpoint()).append(System.lineSeparator());
 
     query = "get edges(Page, ?, Linkto)";
     parameters.clear();
     parameters.put(1, "2");
-    parser = new QueryParser(null, query, parameters, 0, 0, 0);
+    parser = new QueryParser(null, query, parameters, 0, 0);
     sb.append(parser.getEndpoint()).append(System.lineSeparator());
 
     query = "get edges(Page, ?, Linkto, Page)";
     parameters.clear();
     parameters.put(1, "2");
-    parser = new QueryParser(null, query, parameters, 0, 0, 0);
+    parser = new QueryParser(null, query, parameters, 0, 0);
     sb.append(parser.getEndpoint()).append(System.lineSeparator());
 
     query = "get edge(Page, ?, Linkto, Page, ?)";
     parameters.clear();
     parameters.put(1, "2");
     parameters.put(2, "3");
-    parser = new QueryParser(null, query, parameters, 0, 0, 0);
+    parser = new QueryParser(null, query, parameters, 0, 0);
     sb.append(parser.getEndpoint()).append(System.lineSeparator());
 
     query = "run pageRank(maxChange=?, maxIteration=?, dampingFactor=?)";
@@ -61,11 +61,11 @@ public class QueryParserTest extends TestCase {
     parameters.put(1, "0.001");
     parameters.put(2, 10);
     parameters.put(3, "0.15");
-    parser = new QueryParser(null, query, parameters, 0, 0, 0);
+    parser = new QueryParser(null, query, parameters, 0, 0);
     sb.append(parser.getEndpoint()).append(System.lineSeparator());
 
     query = "INSERT INTO vertex Page(id, name, 'page rank', page_id, is_active) VALUES('1000', 'new page', 0.8, 1000, TRue)";
-    parser = new QueryParser(null, query, null, 0, 0, 0);
+    parser = new QueryParser(null, query, null, 0, 0);
     sb.append(parser.getVertexJson()).append(System.lineSeparator());
 
     query = "INSERT INTO vertex Page(id, name, 'page rank', page_id, is_active) VALUES(?, ?, ?, ?, ?)";
@@ -75,11 +75,11 @@ public class QueryParserTest extends TestCase {
     parameters.put(3, 0.8);
     parameters.put(4, 1000);
     parameters.put(5, Boolean.FALSE);
-    parser = new QueryParser(null, query, parameters, 0, 0, 0);
+    parser = new QueryParser(null, query, parameters, 0, 0);
     sb.append(parser.getVertexJson()).append(System.lineSeparator());
 
     query = "INSERT INTO edge Linkto(Page, Page, weight, is_active) VALUES('1000', '1001', 10.7, FaLse)";
-    parser = new QueryParser(null, query, null, 0, 0, 1);
+    parser = new QueryParser(null, query, null, 0, 1);
     sb.append(parser.getEdgeJson()).append(System.lineSeparator());
 
     query = "INSERT INTO edge Linkto(Page, Page, weight, is_active) VALUES(?, ?, ?, ?)";
@@ -88,24 +88,23 @@ public class QueryParserTest extends TestCase {
     parameters.put(2, "1001");
     parameters.put(3, 10.7);
     parameters.put(4, Boolean.TRUE);
-    parser = new QueryParser(null, query, parameters, 0, 0, 0);
+    parser = new QueryParser(null, query, parameters, 0, 0);
     sb.append(parser.getEdgeJson()).append(System.lineSeparator());
 
     query = "builtins stat_vertex_number(type=?)";
     parameters.clear();
     parameters.put(1, "Page");
-    parser = new QueryParser(null, query, parameters, 0, 0, 0);
+    parser = new QueryParser(null, query, parameters, 0, 0);
     sb.append(parser.getPayload()).append(System.lineSeparator());
 
     query = "builtins stat_edge_number(type=?)";
     parameters.clear();
     parameters.put(1, "Linkto");
-    parser = new QueryParser(null, query, parameters, 0, 0, 0);
+    parser = new QueryParser(null, query, parameters, 0, 0);
     sb.append(parser.getPayload()).append(System.lineSeparator());
 
     String formattedResult = sb.toString();
-    InputStream expected =
-      getClass().getClassLoader().getResourceAsStream("endpoint-expected.dat");
+    InputStream expected = getClass().getClassLoader().getResourceAsStream("endpoint-expected.dat");
     String expectedString = IOUtils.toString(expected).replaceAll("\\n|\\r\\n", System.lineSeparator());
     assertEquals(expectedString, formattedResult);
   }

--- a/tools/etl/tg-jdbc-driver/tg-jdbc-driver/src/test/java/com/tigergraph/jdbc/QueryParserTest.java
+++ b/tools/etl/tg-jdbc-driver/tg-jdbc-driver/src/test/java/com/tigergraph/jdbc/QueryParserTest.java
@@ -1,6 +1,7 @@
 package com.tigergraph.jdbc;
 
 import com.tigergraph.jdbc.restpp.driver.QueryParser;
+import com.tigergraph.jdbc.log.TGLoggerFactory;
 import junit.framework.TestCase;
 import org.apache.commons.io.IOUtils;
 
@@ -18,6 +19,7 @@ public class QueryParserTest extends TestCase {
   }
 
   public void testFormat() throws Exception {
+    TGLoggerFactory.initializeLogger(1);
     String query = "get Page(limit=?)";
     Map<Integer, Object> parameters = new HashMap<>(10);
     parameters.put(1, "3");

--- a/tools/etl/tg-jdbc-driver/tg-jdbc-driver/src/test/java/com/tigergraph/jdbc/RequestTest.java
+++ b/tools/etl/tg-jdbc-driver/tg-jdbc-driver/src/test/java/com/tigergraph/jdbc/RequestTest.java
@@ -1,6 +1,7 @@
 package com.tigergraph.jdbc;
 
 import com.github.tomakehurst.wiremock.WireMockServer;
+import com.tigergraph.jdbc.log.TGLoggerFactory;
 import org.junit.jupiter.api.*;
 import java.util.Properties;
 import java.sql.Connection;
@@ -24,6 +25,7 @@ public class RequestTest {
 
   @BeforeAll
   static void prepare() throws Exception {
+    TGLoggerFactory.initializeLogger(1);
     // Mock server for RESTPP
     wireMockServer = new WireMockServer(options().dynamicPort());
     wireMockServer.start();
@@ -63,7 +65,7 @@ public class RequestTest {
   @Test
   @DisplayName("Should get token")
   void sendAuthRequest() throws SQLException, InterruptedException {
-    wireMockServer.verify(1, postRequestedFor(urlEqualTo("/restpp/requesttoken"))
+    wireMockServer.verify(1, postRequestedFor(urlEqualTo("/gsqlserver/gsql/authtoken"))
         .withHeader("Authorization",
             equalTo("Basic " + new String(Base64.getEncoder()
                 .encode(("tigergraph:tigergraph").getBytes()))))

--- a/tools/etl/tg-jdbc-driver/tg-jdbc-driver/src/test/java/com/tigergraph/jdbc/RestppResponseTest.java
+++ b/tools/etl/tg-jdbc-driver/tg-jdbc-driver/src/test/java/com/tigergraph/jdbc/RestppResponseTest.java
@@ -1,6 +1,7 @@
 package com.tigergraph.jdbc;
 
 import com.tigergraph.jdbc.restpp.driver.RestppResponse;
+import com.tigergraph.jdbc.log.TGLoggerFactory;
 import junit.framework.TestCase;
 import org.apache.commons.io.IOUtils;
 
@@ -18,6 +19,7 @@ public class RestppResponseTest extends TestCase {
 	}
 	
 	public void testFormat() throws Exception {
+		TGLoggerFactory.initializeLogger(1);
 		InputStream inputStream =
 					getClass().getClassLoader().getResourceAsStream("response.xml");
     	String content = IOUtils.toString(inputStream, "utf-8");

--- a/tools/etl/tg-jdbc-driver/tg-jdbc-driver/src/test/java/com/tigergraph/jdbc/RestppResultSetTest.java
+++ b/tools/etl/tg-jdbc-driver/tg-jdbc-driver/src/test/java/com/tigergraph/jdbc/RestppResultSetTest.java
@@ -1,6 +1,7 @@
 package com.tigergraph.jdbc;
 
 import com.tigergraph.jdbc.restpp.RestppResultSet;
+import com.tigergraph.jdbc.log.TGLoggerFactory;
 import com.tigergraph.jdbc.restpp.driver.QueryType;
 import junit.framework.TestCase;
 import org.apache.commons.io.IOUtils;
@@ -20,6 +21,7 @@ public class RestppResultSetTest extends TestCase {
     }
 
     public void testParseResult() throws Exception {
+        TGLoggerFactory.initializeLogger(1);
         List<JSONObject> resultList = new ArrayList<>();
         List<String> field_list = new ArrayList<>();
 

--- a/tools/etl/tg-jdbc-driver/tg-jdbc-driver/src/test/java/com/tigergraph/jdbc/log/TGLoggerFactoryTest.java
+++ b/tools/etl/tg-jdbc-driver/tg-jdbc-driver/src/test/java/com/tigergraph/jdbc/log/TGLoggerFactoryTest.java
@@ -1,0 +1,58 @@
+package com.tigergraph.jdbc.log;
+
+import org.junit.jupiter.api.*;
+import org.slf4j.Logger;
+
+import static org.junit.Assert.*;
+
+public class TGLoggerFactoryTest {
+
+    @Test
+    public void shouldGetJULByDefault(){
+        TGLoggerFactory.initializeLogger(2);
+        Logger logger = TGLoggerFactory.getLogger(TGLoggerFactoryTest.class);
+        assertTrue(logger instanceof JULAdapter);
+        assertEquals("JUL_DEFAULT", TGLoggerFactory.getLoggerType());
+    }
+
+    @Test
+    public void shouldGetJULWithNonSLF4JProperty(){
+        System.setProperty("com.tigergraph.jdbc.loggerImpl", "arbitrary_impl");
+        TGLoggerFactory.initializeLogger(2);
+        Logger logger = TGLoggerFactory.getLogger(TGLoggerFactoryTest.class);
+        assertTrue(logger instanceof JULAdapter);
+        assertEquals("JUL_DEFAULT", TGLoggerFactory.getLoggerType());
+        System.clearProperty("com.tigergraph.jdbc.loggerImpl");
+
+    }
+
+    @Test
+    public void shouldGetJULWithConfig(){
+        System.setProperty("java.util.logging.config.file", "path_to_config_file");
+        TGLoggerFactory.initializeLogger(2);
+        Logger logger = TGLoggerFactory.getLogger(TGLoggerFactoryTest.class);
+        assertTrue(logger instanceof JULAdapter);
+        assertEquals("JUL_WITH_CONFIG", TGLoggerFactory.getLoggerType());
+        System.clearProperty("java.util.logging.config.file");
+    }
+
+    @Test
+    public void shouldGetSLF4JLoggerWithSLF4JProperty(){
+        System.setProperty("com.tigergraph.jdbc.loggerImpl", "SLF4J");
+        TGLoggerFactory.initializeLogger(2);
+        Logger logger = TGLoggerFactory.getLogger(TGLoggerFactoryTest.class);
+        assertFalse(logger instanceof JULAdapter);
+        assertEquals("SLF4J", TGLoggerFactory.getLoggerType());
+        System.clearProperty("com.tigergraph.jdbc.loggerImpl");
+    }
+
+    @Test
+    public void shouldGetSLF4JLoggerWithSLF4JPropertyIgnoreCase(){
+        System.setProperty("com.tigergraph.jdbc.loggerImpl", "sLf4J");
+        TGLoggerFactory.initializeLogger(2);
+        Logger logger = TGLoggerFactory.getLogger(TGLoggerFactoryTest.class);
+        assertFalse(logger instanceof JULAdapter);
+        assertEquals("SLF4J", TGLoggerFactory.getLoggerType());
+        System.clearProperty("com.tigergraph.jdbc.loggerImpl");
+    }
+}

--- a/tools/etl/tg-jdbc-driver/tg-jdbc-driver/src/test/java/com/tigergraph/jdbc/log/TGLoggerFactoryTest.java
+++ b/tools/etl/tg-jdbc-driver/tg-jdbc-driver/src/test/java/com/tigergraph/jdbc/log/TGLoggerFactoryTest.java
@@ -9,7 +9,7 @@ public class TGLoggerFactoryTest {
 
     @Test
     public void shouldGetJULByDefault(){
-        TGLoggerFactory.initializeLogger(2);
+        TGLoggerFactory.initializeLogger(1);
         Logger logger = TGLoggerFactory.getLogger(TGLoggerFactoryTest.class);
         assertTrue(logger instanceof JULAdapter);
         assertEquals("JUL_DEFAULT", TGLoggerFactory.getLoggerType());
@@ -18,7 +18,7 @@ public class TGLoggerFactoryTest {
     @Test
     public void shouldGetJULWithNonSLF4JProperty(){
         System.setProperty("com.tigergraph.jdbc.loggerImpl", "arbitrary_impl");
-        TGLoggerFactory.initializeLogger(2);
+        TGLoggerFactory.initializeLogger(1);
         Logger logger = TGLoggerFactory.getLogger(TGLoggerFactoryTest.class);
         assertTrue(logger instanceof JULAdapter);
         assertEquals("JUL_DEFAULT", TGLoggerFactory.getLoggerType());
@@ -29,7 +29,7 @@ public class TGLoggerFactoryTest {
     @Test
     public void shouldGetJULWithConfig(){
         System.setProperty("java.util.logging.config.file", "path_to_config_file");
-        TGLoggerFactory.initializeLogger(2);
+        TGLoggerFactory.initializeLogger(1);
         Logger logger = TGLoggerFactory.getLogger(TGLoggerFactoryTest.class);
         assertTrue(logger instanceof JULAdapter);
         assertEquals("JUL_WITH_CONFIG", TGLoggerFactory.getLoggerType());
@@ -39,7 +39,7 @@ public class TGLoggerFactoryTest {
     @Test
     public void shouldGetSLF4JLoggerWithSLF4JProperty(){
         System.setProperty("com.tigergraph.jdbc.loggerImpl", "SLF4J");
-        TGLoggerFactory.initializeLogger(2);
+        TGLoggerFactory.initializeLogger(1);
         Logger logger = TGLoggerFactory.getLogger(TGLoggerFactoryTest.class);
         assertFalse(logger instanceof JULAdapter);
         assertEquals("SLF4J", TGLoggerFactory.getLoggerType());
@@ -49,7 +49,7 @@ public class TGLoggerFactoryTest {
     @Test
     public void shouldGetSLF4JLoggerWithSLF4JPropertyIgnoreCase(){
         System.setProperty("com.tigergraph.jdbc.loggerImpl", "sLf4J");
-        TGLoggerFactory.initializeLogger(2);
+        TGLoggerFactory.initializeLogger(1);
         Logger logger = TGLoggerFactory.getLogger(TGLoggerFactoryTest.class);
         assertFalse(logger instanceof JULAdapter);
         assertEquals("SLF4J", TGLoggerFactory.getLoggerType());

--- a/tools/etl/tg-jdbc-driver/tg-jdbc-driver/src/test/java/com/tigergraph/jdbc/log/UtilTest.java
+++ b/tools/etl/tg-jdbc-driver/tg-jdbc-driver/src/test/java/com/tigergraph/jdbc/log/UtilTest.java
@@ -1,0 +1,43 @@
+package com.tigergraph.jdbc.log;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.*;
+
+public class UtilTest {
+
+    @Test
+    public void shouldConvertToJULFormat0() {
+        assertEquals("Hello {0}, this is {1}", Util.formatConverter("Hello {}, this is {}"));
+    }
+
+    @Test
+    public void shouldConvertToJULFormat1() {
+        assertEquals("Hello {{0}}}, this is {1}", Util.formatConverter("Hello {{}}}, this is {}"));
+    }
+
+    @Test
+    public void shouldConvertToJULFormat2() {
+        assertEquals("Hello }, this is {0}", Util.formatConverter("Hello }, this is {}"));
+    }
+
+    @Test
+    public void shouldConvertToJULFormat4() {
+        assertEquals("Hello {, this is {0}", Util.formatConverter("Hello {, this is {}"));
+    }
+
+    @Test
+    public void shouldConvertToJULFormat5() {
+        assertEquals("Hello {0}, this is {1}", Util.formatConverter("Hello {0}, this is {1}"));
+    }
+
+    @Test
+    public void shouldConvertToJULFormat7() {
+        assertEquals("Hello {0}, this is {", Util.formatConverter("Hello {}, this is {"));
+    }
+
+    @Test
+    public void shouldConvertToJULFormat6() {
+        assertEquals("Hello {0}, this is {", Util.formatConverter("Hello {0}, this is {"));
+    }
+}


### PR DESCRIPTION
- Add JUL and SLF4J logging frameworks(reviewed)
- Re-call sparkfiles.get in jdbc to get the jks file
  - call sparkfiles.get in spark script can only get the path of jks in driver, and it doesn't work for worker nodes when in cluster mode.
  - invoke sparkfiles.get in jdbc, and set the scope of spark-core to "provided" to avoid conflicts and keep the jar slim.
- Add version selection for tigergraph
  - It is inconvenient to release a corresponding jdbc for each version of tigergraph
  - users now can specify the version of tg(3.5 by default)
- Testing:
  - test with spark cluster
  - test with tg 3.4 and 3.5