### PR TITLE
Hyperlink fix

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -97,7 +97,7 @@ The process described here has several goals:
 
 Please follow these steps to have your contribution considered by the maintainers:
 
-1. Follow all instructions in [the template](PULL_REQUEST_TEMPLATE.md)
+1. Follow all instructions in [the template](https://github.com/tigergraph/ecosys/blob/master/docs/PULL_REQUEST_TEMPLATE.md)
 2. Follow the [styleguides](#styleguides)
 3. After you submit your pull request, a reviewer(s) may ask you to complete additional design work, tests, or other changes before your pull request can be ultimately accepted.
 

--- a/tools/etl/tg-jdbc-driver/README.md
+++ b/tools/etl/tg-jdbc-driver/README.md
@@ -123,7 +123,7 @@ try {
 
 Don't forget to use `jdbc:tg:https:` as its prefix instead of `jdbc:tg:http:`. The certificate needs to be converted to JKS format.
 
-Detailed example can be found at [GraphQuery.java](tg-jdbc-examples/src/main/java/com/tigergraph/jdbc/GraphQuery.java).
+Detailed example can be found at [GraphQuery.java](https://github.com/tigergraph/ecosys/blob/master/tools/etl/tg-jdbc-driver/tg-jdbc-examples/src/main/java/com/tigergraph/jdbc/examples/GraphQuery.java).
 
 ## Connection Pool
 This JDBC driver could be used in together with third party connection pools. For instance, [HikariCP](https://github.com/brettwooldridge/HikariCP).
@@ -170,7 +170,7 @@ config.addDataSourceProperty("trustStorePassword", "password");
 config.addDataSourceProperty("trustStoreType", "JKS");
 ```
 
-Detailed example can be found at [ConnectionPool.java](tg-jdbc-examples/src/main/java/com/tigergraph/jdbc/ConnectionPool.java).
+Detailed example can be found at [ConnectionPool.java](https://github.com/tigergraph/ecosys/blob/master/tools/etl/tg-jdbc-driver/tg-jdbc-examples/src/main/java/com/tigergraph/jdbc/examples/ConnectionPool.java).
 
 ## Supported Queries
 ```


### PR DESCRIPTION
At a minimum please provide the following:

### Description of the Change

Fix broken hyperlinks I came across while referencing the docs.

Mainly in the jdbc and contributing markdowns.

An example of a broken link:

![image](https://user-images.githubusercontent.com/63341400/170628138-4757bdc2-aef8-43a0-8d70-5088234834ee.png)

![image](https://user-images.githubusercontent.com/63341400/170628186-20ec50de-df41-4473-8d86-a2c6d4fffc69.png)


### Release Notes

NA

