### PR TITLE
[QA-4212] add Kafka SSL authentication files generation scripts

### DIFF
--- a/tools/kafka_sasl_ssl/generate_sasl_keyTab/create_keytab.sh
+++ b/tools/kafka_sasl_ssl/generate_sasl_keyTab/create_keytab.sh
@@ -1,0 +1,101 @@
+#!/bin/bash
+# The example: bash create_keytab.sh ~/kafka/private/keytab tiger123 kafka-0.tigergraph.com TIGERGRAPH.COM
+# generate_root: keyTab files generation path
+# pass: KDC database master key
+# hostname: Kafka server hostname
+# realm: everyone agrees to name realms in uppercase, such as "EXAMPLE.COM"
+
+if [ $# -eq 4 ]; then
+  generate_root=$1
+  pass=$2
+  hostname=$3
+  realm=$4
+else
+  echo "shell script input check failed."
+  exit 1
+fi
+
+# install Kerberos server in centos os
+if [ -d "/etc/yum.repos.d" ]; then
+  if ! rpm -qa | grep krb5-server > /dev/null 2>&1;then
+    sudo yum install krb5-libs krb5-workstation -y > /dev/null 2>&1
+    sudo yum install krb5-server -y > /dev/null 2>&1
+  else
+    echo "Kerberos has been installed."
+  fi
+else
+  echo "unsupported os"
+fi
+
+config_file=/etc/krb5.conf
+realm_lower=`echo $realm | awk '{print tolower($0)}'`
+if [ ! -f ${config_file} ]; then
+  echo "${config_file} not found."
+  exit 1
+else
+  # From the default file, replace the realm EXAMPLE.COM with your realm.
+  # Replace also the domain in lowercase with your domain in the [domain_realm] section.
+  sudo su -c "echo \"includedir /etc/krb5.conf.d/
+
+[logging]
+ default = FILE:/var/log/krb5libs.log
+ kdc = FILE:/var/log/krb5kdc.log
+ admin_server = FILE:/var/log/kadmind.log
+
+[libdefaults]
+ dns_lookup_realm = false
+ ticket_lifetime = 24h
+ # renew_lifetime = 7d
+ forwardable = true
+ rdns = false
+ pkinit_anchors = FILE:/etc/pki/tls/certs/ca-bundle.crt
+ default_realm = ${realm}
+ default_ccache_name = KEYRING:persistent:%{uid}
+
+[realms]
+ ${realm} = {
+  kdc = ${hostname}
+  admin_server = ${hostname}
+ }
+
+[domain_realm]
+ .${realm_lower} = ${realm}
+ ${realm_lower} = ${realm}
+\" > ${config_file}"
+
+  # delete old Kerberos database password
+  cd /var/kerberos/krb5kdc
+  sudo rm -rf principal*
+
+  # Create the Kerberos database
+  echo -e "${pass}\n${pass}" | sudo kdb5_util create -s -r ${realm}
+
+  # generate new keytab files
+  rm -rf ${generate_root}
+  mkdir -p ${generate_root}
+
+  # Start and enable Kerberos services as system services
+  sudo systemctl start krb5kdc kadmin
+  sudo systemctl enable krb5kdc kadmin
+
+  cd $generate_root
+  # Create principals and keytab files
+  # create principals for Kafka clients
+  sudo kadmin.local -q "addprinc -randkey kafka-client@${realm}"
+  # create principals for Kafka broker.
+  # "kafka" will be the service name.
+  sudo kadmin.local -q "addprinc -randkey kafka/${hostname}@${realm}"
+  # create kafka client keytab files.
+  sudo kadmin.local -q "ktadd -k ${generate_root}/kafka-client.keytab kafka-client@${realm}"
+  # create kafka server keytab files.
+  sudo kadmin.local -q "ktadd -k ${generate_root}/kafka-servers.keytab kafka/${hostname}@${realm}"
+
+  #check the keytab file
+  keytab_num=$(sudo klist -e -k -t ${generate_root}/kafka-client.keytab  | grep -c "kafka-client@${realm}")
+  if [ ${keytab_num} -gt 0 ]; then
+    echo "keytab file create successfully."
+  else
+    echo "keytab file create failed."
+    exit 1
+  fi
+fi

--- a/tools/kafka_sasl_ssl/generate_sasl_keyTab/create_keytab.sh
+++ b/tools/kafka_sasl_ssl/generate_sasl_keyTab/create_keytab.sh
@@ -27,7 +27,9 @@ else
   echo "unsupported os"
 fi
 
-config_file=/etc/krb5.conf
+krb5_config_file=/etc/krb5.conf
+kadm5_acl_file=/var/kerberos/krb5kdc/kadm5.acl
+kdc_conf_file=/var/kerberos/krb5kdc/kdc.conf
 realm_lower=`echo $realm | awk '{print tolower($0)}'`
 if [ ! -f ${config_file} ]; then
   echo "${config_file} not found."
@@ -61,7 +63,10 @@ else
 [domain_realm]
  .${realm_lower} = ${realm}
  ${realm_lower} = ${realm}
-\" > ${config_file}"
+\" > ${krb5_config_file}"
+
+  sudo sed -i "s/EXAMPLE.COM/${realm}/g" $kadm5_acl_file
+  sudo sed -i "s/EXAMPLE.COM/${realm}/g" $kdc_conf_file
 
   # delete old Kerberos database password
   cd /var/kerberos/krb5kdc

--- a/tools/kafka_sasl_ssl/generate_ssl_CA/ssl_one_way.sh
+++ b/tools/kafka_sasl_ssl/generate_ssl_CA/ssl_one_way.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+# The example: bash ssl_one_way.sh kafka-0.tigergraph.com ~/SSL_one_way tiger123
+# The example password: tiger123
+# The example server host name: kafka-0.tigergraph.com
+# The certificate generation path: ~/SSL_one_way
+
+if [ $# -eq 3 ]; then
+  server_hostname=$1
+  generate_root=$2
+  pass=$3
+else
+  echo "Error in parameter. Please check."
+  echo "e.g. bash ssl_one_way.sh server_hostname generate_root password"
+  exit 1
+fi
+
+env_prepare(){
+  # install java
+  if ! which java > /dev/null 2>&1; then
+    echo "start install openjdk."
+    sudo yum update -y > /dev/null 2>&1
+    sudo yum install -y java-1.8.0-openjdk > /dev/null 2>&1
+    echo "install openjdk-1.8.0 successfully."
+  else
+    java_version=$(java -version 2>&1 | sed '1!d' | sed -e 's/"//g' | awk '{print $3}'| cut -d_ -f1)
+    if [[ $java_version != "1.8.0" ]];then
+      echo "start upgrade java."
+      rpm -qa | grep java | sudo xargs rpm -e --nodeps
+      sudo yum update -y > /dev/null 2>&1
+      sudo yum install -y java-1.8.0-openjdk > /dev/null 2>&1
+      echo "install openjdk-1.8.0 successfully."
+    else
+      echo "The java version is openjdk-1.8.0 now."
+    fi
+  fi
+
+  # install openssl
+  if ! openssl version > /dev/null 2>&1;then
+    sudo yum -y install openssl > /dev/null 2>&1
+  fi
+}
+
+ssl_oneway_ca_generate(){
+  if [ ! -d ${generate_root} ]; then
+    mkdir -p ${generate_root}
+  fi
+
+  cd $generate_root
+  echo "start create certificates..."
+  sudo keytool -keystore server.keystore.jks -alias ${server_hostname} -validity 365 -genkey -keyalg RSA -dname "cn=${server_hostname}" -storepass ${pass} -keypass ${pass}
+  sudo openssl req -nodes -new -x509 -keyout ca-root.key -out ca-root.crt -days 365 -subj "/C=US/ST=CA/L=Palo Alto/O=Confluent/CN=Confluent"
+  echo ${pass} | sudo keytool -keystore server.keystore.jks -alias ${server_hostname} -certreq -file ${server_hostname}_server.csr
+  sudo openssl x509 -req -CA ca-root.crt -CAkey ca-root.key -in ${server_hostname}_server.csr -out ${server_hostname}_server.crt -days 365 -CAcreateserial
+  echo ${pass} | sudo keytool -keystore server.keystore.jks -alias CARoot -import -noprompt -file ca-root.crt
+  echo ${pass} | sudo keytool -keystore server.keystore.jks -alias ${server_hostname} -import -file ${server_hostname}_server.crt
+  echo -e "${pass}\n${pass}\ny" | sudo keytool -keystore server.truststore.jks -alias CARoot -import -file ca-root.crt
+
+  if [ $? != 0 ]; then
+    echo "failed to generate certificates."
+    exit 1
+  else
+    echo "certificates generated successfully."
+  fi
+}
+
+env_prepare
+ssl_oneway_ca_generate ${server_hostname} ${generate_root} ${pass}

--- a/tools/kafka_sasl_ssl/generate_ssl_CA/ssl_two_way.sh
+++ b/tools/kafka_sasl_ssl/generate_ssl_CA/ssl_two_way.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+# The example: bash ssl_two_way.sh kafka-0.tigergraph.com tigergraph ~/SSL_two_way tiger123
+# The example password: tiger123
+# The example server host name: kafka-0.tigergraph.com
+# The example client host name: tigergraph
+# The certificate generation path: ~/SSL_two_way
+
+if [ $# -eq 4 ]; then
+  server_hostname=$1
+  client_hostname=$2
+  generate_root=$3
+  pass=$4
+else
+  echo "Error in parameter. Please check."
+  echo "e.g. bash ssl_two_way.sh server_hostname client_hostname generate_root password"
+  exit 1
+fi
+
+env_prepare(){
+  # install java
+  if ! which java > /dev/null 2>&1; then
+    echo "start install openjdk."
+    sudo yum update -y > /dev/null 2>&1
+    sudo yum install -y java-1.8.0-openjdk > /dev/null 2>&1
+    echo "install openjdk-1.8.0 successfully."
+  else
+    java_version=$(java -version 2>&1 | sed '1!d' | sed -e 's/"//g' | awk '{print $3}'| cut -d_ -f1)
+    if [[ $java_version != "1.8.0" ]];then
+      echo "start upgrade java."
+      rpm -qa | grep java | sudo xargs rpm -e --nodeps
+      sudo yum update -y > /dev/null 2>&1
+      sudo yum install -y java-1.8.0-openjdk > /dev/null 2>&1
+      echo "install openjdk-1.8.0 successfully."
+    else
+      echo "The java version is openjdk-1.8.0 now."
+    fi
+  fi
+
+  # install openssl
+  if ! openssl version > /dev/null 2>&1;then
+    sudo yum -y install openssl > /dev/null 2>&1
+  fi
+}
+
+ssl_twoway_ca_generate(){
+  if [ ! -d ${generate_root} ]; then
+    mkdir -p ${generate_root}
+  fi
+
+  cd $generate_root
+  echo "start create certificates for kafka broker..."
+  sudo keytool -keystore server.keystore.jks -alias ${server_hostname} -validity 365 -genkey -keyalg RSA -dname "cn=${server_hostname}" -storepass ${pass} -keypass ${pass}
+  sudo openssl req -nodes -new -x509 -keyout ca-root.key -out ca-root.crt -days 365 -subj "/C=US/ST=CA/L=Palo Alto/O=Confluent/CN=Confluent"
+  echo ${pass} | sudo keytool -keystore server.keystore.jks -alias ${server_hostname} -certreq -file ${server_hostname}_server.csr
+  sudo openssl x509 -req -CA ca-root.crt -CAkey ca-root.key -in ${server_hostname}_server.csr -out ${server_hostname}_server.crt -days 365 -CAcreateserial
+  echo ${pass} | sudo keytool -keystore server.keystore.jks -alias CARoot -import -noprompt -file ca-root.crt
+  echo ${pass} | sudo keytool -keystore server.keystore.jks -alias ${server_hostname} -import -file ${server_hostname}_server.crt
+
+  echo "start generate private key / public key certificate pair for the client..."
+  sudo openssl req -newkey rsa:2048 -nodes -keyout ${client_hostname}_client.key -out ${client_hostname}_client.csr -subj "/C=US/ST=CA/L=Palo Alto/O=Confluent/CN=Confluent"
+  sudo openssl x509 -req -CA ca-root.crt -CAkey ca-root.key -in ${client_hostname}_client.csr -out ${client_hostname}_client.crt -days 365 -CAcreateserial
+  echo -e "${pass}\n${pass}\ny" | sudo keytool -keystore server.truststore.jks -alias CARoot -import -file ca-root.crt
+
+  if [ $? != 0 ]; then
+    echo "failed to generate certificates."
+    exit 1
+  else
+    echo "certificates generated successfully."
+  fi
+}
+
+env_prepare
+ssl_twoway_ca_generate ${server_hostname} ${generate_root} ${pass}


### PR DESCRIPTION
At a minimum please provide the following:

### Description of the Change
Add Kafka SSL Self Signed Certificates generation scripts. Including some ca, keystore, truststore files.
Refer to:  https://graphsql.atlassian.net/browse/QA-4212
<!-- 

We must be able to understand the purpose of your change from this description.

-->

### Release Notes

<!--

Please describe the changes in a single line that explains this improvement in
terms that a user can understand.

If this change is not user-facing or notable enough to be included in release notes
you may use the strings "Not applicable" or "N/A" here.

Examples:

- The GitHub package now allows you to add co-authors to commits.
- Fixed an issue where multiple cursors did not work in a file with a single line.
- Increased the performance of searching and replacing across a whole project.

-->
