### PR TITLE
TP-3270 feat(k8s): Deprecate the repo of K8s classic; 

### DIFF
--- a/k8s/README.md
+++ b/k8s/README.md
@@ -1,3 +1,4 @@
+# This project has been deprecated. Please use [Tigergraph Kubernetes Operator](https://docs.tigergraph.com/tigergraph-server/current/kubernetes/k8s-operator/) to create managed Tigergraph cluster instances on Kubernetes(GKE/EKS/OpenShift).
 # Run Tigergraph in EKS/GKE/AKS
 
 ## Getting Started

--- a/k8s/README.md
+++ b/k8s/README.md
@@ -1,4 +1,5 @@
 # This project has been deprecated. Please use [Tigergraph Kubernetes Operator](https://docs.tigergraph.com/tigergraph-server/current/kubernetes/k8s-operator/) to create managed Tigergraph cluster instances on Kubernetes(GKE/EKS/OpenShift).
+
 # Run Tigergraph in EKS/GKE/AKS
 
 ## Getting Started


### PR DESCRIPTION
At a minimum please provide the following:

### Description of the Change

- Deprecate the repo of K8s classic

### Release Notes
Add Deprecated notes and pointed URL to K8s Operator in the repo of K8s classic.

Examples:

