### PR TITLE
Update K8s docs for Operator 1.4.0

### DIFF
--- a/k8s/README.md
+++ b/k8s/README.md
@@ -12,6 +12,7 @@ Understanding the intricate synergy between TigerGraph, TigerGraph Operator, and
 
 | TigerGraph Operator version | TigerGraph version  | Kubernetes version |
 |----------|----------|----------|
+| 1.4.0 | TigerGraph >= 3.6.0 && TigerGraph <= 4.1.2|1.25, 1.26, 1.27, 1.28, 1.29|
 | 1.3.0 | TigerGraph >= 3.6.0 && TigerGraph <= 4.1.1|1.25, 1.26, 1.27, 1.28, 1.29|
 | 1.2.0 | TigerGraph >= 3.6.0 && TigerGraph <= 4.1.0|1.25, 1.26, 1.27, 1.28, 1.29|
 | 1.1.0 | TigerGraph >= 3.6.0 && TigerGraph <= 3.10.1|1.24, 1.25, 1.26, 1.27, 1.28|

--- a/k8s/docs/01-introduction/README.md
+++ b/k8s/docs/01-introduction/README.md
@@ -12,6 +12,7 @@ Understanding the intricate synergy between TigerGraph, TigerGraph Operator, and
 
 | TigerGraph Operator version | TigerGraph version  | Kubernetes version |
 |----------|----------|----------|
+| 1.4.0 | TigerGraph >= 3.6.0 && TigerGraph <= 4.1.2|1.25, 1.26, 1.27, 1.28, 1.29|
 | 1.3.0 | TigerGraph >= 3.6.0 && TigerGraph <= 4.1.1|1.25, 1.26, 1.27, 1.28, 1.29|
 | 1.2.0 | TigerGraph >= 3.6.0 && TigerGraph <= 4.1.0|1.25, 1.26, 1.27, 1.28, 1.29|
 | 1.1.1 | TigerGraph >= 3.6.0 && TigerGraph <= 3.10.2|1.25, 1.26, 1.27, 1.28, 1.29|

--- a/k8s/docs/07-reference/api-reference.md
+++ b/k8s/docs/07-reference/api-reference.md
@@ -324,6 +324,32 @@ map[string]string
 </tr>
 <tr>
 <td>
+<code>podInitLabels</code></br>
+<em>
+map[string]string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>PodInitLabels will be added to metadata.labels field of spec.template (PodTemplateSpec)
+in the StatefulSet used to manage TigerGraph Pods.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>podInitAnnotations</code></br>
+<em>
+map[string]string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>PodInitAnnotations will be added to the metadata.annotations field of spec.template (PodTemplateSpec)
+in the StatefulSet used to manage TigerGraph Pods.</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>pause</code></br>
 <em>
 bool
@@ -1235,6 +1261,49 @@ S3Bucket
 </tr>
 </tbody>
 </table>
+<h3 id="graphdb.tigergraph.com/v1alpha1.HostListItem">HostListItem</h3>
+<p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>Hostname</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>ID</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>Region</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
 <h3 id="graphdb.tigergraph.com/v1alpha1.IngressRule">IngressRule</h3>
 <p>
 (<em>Appears on:</em>
@@ -1449,6 +1518,18 @@ which can be set to LoadBalancer, NodePort, and Ingress</p>
 </tr>
 <tr>
 <td>
+<code>port</code></br>
+<em>
+int32
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ServicePort is the port that is exposed by a LoadBalancer service.</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>nginxNodePort</code></br>
 <em>
 int32
@@ -1557,6 +1638,18 @@ int32
 </td>
 <td>
 <p>The port that exposes in sidecar container</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>targetPort</code></br>
+<em>
+int32
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>TargetPort is the internal port to access on the pods targeted by the service</p>
 </td>
 </tr>
 <tr>
@@ -2820,6 +2913,32 @@ map[string]string
 </tr>
 <tr>
 <td>
+<code>podInitLabels</code></br>
+<em>
+map[string]string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>PodInitLabels will be added to metadata.labels field of spec.template (PodTemplateSpec)
+in the StatefulSet used to manage TigerGraph Pods.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>podInitAnnotations</code></br>
+<em>
+map[string]string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>PodInitAnnotations will be added to the metadata.annotations field of spec.template (PodTemplateSpec)
+in the StatefulSet used to manage TigerGraph Pods.</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>pause</code></br>
 <em>
 bool
@@ -3033,6 +3152,28 @@ map[string]string
 </td>
 <td>
 <p>Current customized annotations of TigerGraph Pods</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>podInitLabels</code></br>
+<em>
+map[string]string
+</em>
+</td>
+<td>
+<p>Current customized labels of PodTemplateSpec in StatefulSet used to manage TigerGraph Pods</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>podInitAnnotations</code></br>
+<em>
+map[string]string
+</em>
+</td>
+<td>
+<p>Current customized annotations of PodTemplateSpec in StatefulSet used to manage TigerGraph Pods</p>
 </td>
 </tr>
 <tr>

--- a/k8s/docs/08-release-notes/README.md
+++ b/k8s/docs/08-release-notes/README.md
@@ -7,6 +7,7 @@ Those document describes the new features, improvements, bugfixes for all of Tig
 
 Please see the detailed documentation of each TigerGraph Operator version release notes as follows:
 
+- [TigerGraph Operator 1.4.0](./operator-1.4.0.md)
 - [TigerGraph Operator 1.3.0](./operator-1.3.0.md)
 - [TigerGraph Operator 1.2.0](./operator-1.2.0.md)
 - [TigerGraph Operator 1.1.1](./operator-1.1.1.md)

--- a/k8s/docs/08-release-notes/operator-0.0.3.md
+++ b/k8s/docs/08-release-notes/operator-0.0.3.md
@@ -31,4 +31,4 @@ sudo install kubectl-tg /usr/local/bin/
 
 ## Bugfixes
 
-- Addressed an issue where the expand command would become stuck when no schema and graph data existed in the TigerGraph cluster. ([CORE-1743](https://graphsql.atlassian.net/browse/CORE-1743), TigerGraph 3.8.0)
+- Addressed an issue where the expand command would become stuck when no schema and graph data existed in the TigerGraph cluster.

--- a/k8s/docs/08-release-notes/operator-0.0.5.md
+++ b/k8s/docs/08-release-notes/operator-0.0.5.md
@@ -47,4 +47,4 @@ kubectl tg upgrade --namespace ${NAMESPACE_OF_OPERATOR} --operator-version 0.0.5
 
 - Job Name Length: Added a hint when the job name exceeds the RFC 1123 character limit.
 
-- Fixed an issue where expansion or shrink operations on an empty queue would skip pausing GPE. ([CORE-2440](https://graphsql.atlassian.net/browse/CORE-2440), TigerGraph 3.9.1)
+- Fixed an issue where expansion or shrink operations on an empty queue would skip pausing GPE.

--- a/k8s/docs/08-release-notes/operator-0.0.7.md
+++ b/k8s/docs/08-release-notes/operator-0.0.7.md
@@ -53,14 +53,14 @@ kubectl tg upgrade --namespace ${NAMESPACE_OF_OPERATOR} --operator-version 0.0.7
 
 - Fixed the problem of external services updating twice, which led to errors.
 
-- Corrected unexpected config updates when executing an overlap operation between upgrade and expansion. ([TP-3646](https://graphsql.atlassian.net/browse/TP-3646))
+- Corrected unexpected config updates when executing an overlap operation between upgrade and expansion.
 
-- Addressed an incorrect error exit issue in the upgrade script. ([TP-3869](https://graphsql.atlassian.net/browse/TP-3869))
+- Addressed an incorrect error exit issue in the upgrade script.
 
 - Fixed the issue of cluster status checking during expansion and shrinking. It now checks the service of all nodes, not just the client node.
 
-- Graph query responses no longer encounter errors after successful execution of the expansion. ([GLE-5195](https://graphsql.atlassian.net/jira/software/c/projects/GLE/issues/GLE-5195), TigerGraph 3.9.2)
+- Graph query responses no longer encounter errors after successful execution of the expansion.
 
-- Resolved the issue of cluster size limits during cluster expansion. ([TP-3768](https://graphsql.atlassian.net/browse/TP-3768))
+- Resolved the issue of cluster size limits during cluster expansion.
 
-- Fixed unnecessary rolling update problems that occurred when upgrading from 3.7.0 and below to 3.9.0 and above. ([TP-3765](https://graphsql.atlassian.net/browse/TP-3765) & [CORE-2585](https://graphsql.atlassian.net/browse/CORE-2585))
+- Fixed unnecessary rolling update problems that occurred when upgrading from 3.7.0 and below to 3.9.0 and above.

--- a/k8s/docs/08-release-notes/operator-0.0.9.md
+++ b/k8s/docs/08-release-notes/operator-0.0.9.md
@@ -42,30 +42,30 @@ kubectl tg upgrade --namespace ${NAMESPACE_OF_OPERATOR} --operator-version 0.0.9
 
 ## New features
 
-- CompressLevel is now supported in `TigerGraphBackup` and `TigerGraphBackupSchedule`, with support for DecompressProcessNumber in TigerGraphRestore. These features require a cluster version of 3.9.3 or higher.([TP-4017](https://graphsql.atlassian.net/browse/TP-4017))
+- CompressLevel is now supported in `TigerGraphBackup` and `TigerGraphBackupSchedule`, with support for DecompressProcessNumber in TigerGraphRestore. These features require a cluster version of 3.9.3 or higher.
 
 ## Improvements
 
-- The help message menu for the `kubectl-tg` plugin has been enhanced. ([TP-3915](https://graphsql.atlassian.net/browse/TP-3915))
+- The help message menu for the `kubectl-tg` plugin has been enhanced.
 
-- The `.spec.initTGConfig.version` field in TigerGraph CR is now optional. You no longer need to specify this field when creating or updating the CR. ([TP-3910](https://graphsql.atlassian.net/browse/TP-3910))
+- The `.spec.initTGConfig.version` field in TigerGraph CR is now optional. You no longer need to specify this field when creating or updating the CR.
 
-- Static passwords have been replaced with private keys for executing cluster operations jobs. ([TP-3792](https://graphsql.atlassian.net/browse/TP-3792))
+- Static passwords have been replaced with private keys for executing cluster operations jobs.
 
-- The make command has been added to support the installation of tsar, and password usage has been disabled when building the TG docker image. ([TP-3786](https://graphsql.atlassian.net/browse/TP-3786))
+- The make command has been added to support the installation of tsar, and password usage has been disabled when building the TG docker image.
 
-- Support for automatic restart of TigerGraph service under any circumstances has been introduced. ([TP-3848](https://graphsql.atlassian.net/browse/TP-3848) Database change)
+- Support for automatic restart of TigerGraph service under any circumstances has been introduced.
 
-- Service auto-restart in the Operator can now be enabled by setting the TG configuration Controller.ServiceManager.AutoRestart. ([TP-4045](https://graphsql.atlassian.net/browse/TP-4045))
+- Service auto-restart in the Operator can now be enabled by setting the TG configuration Controller.ServiceManager.AutoRestart.
 
 ## Bugfixes
 
-- A situation where the cluster was cloned again when a restore had already succeeded has been rectified. ([TP-3948](https://graphsql.atlassian.net/browse/TP-3948))
+- A situation where the cluster was cloned again when a restore had already succeeded has been rectified.
 
-- A problem with error handling in the TG container's PostStart Handler script has been resolved. ([TP-3914](https://graphsql.atlassian.net/browse/TP-3914))
+- A problem with error handling in the TG container's PostStart Handler script has been resolved.
 
-- A restpp status refresh issue has been addressed. ([CORE-1905](https://graphsql.atlassian.net/browse/CORE-1905))
+- A restpp status refresh issue has been addressed.
 
-- GSQL jobs no longer get stuck when some related services are down. ([GLE-5365](https://graphsql.atlassian.net/browse/GLE-5365))
+- GSQL jobs no longer get stuck when some related services are down.
 
-- An issue where expansion was stuck at importing gsql/gui has been fixed. ([TOOLS-2306](https://graphsql.atlassian.net/browse/TOOLS-2306))
+- An issue where expansion was stuck at importing gsql/gui has been fixed.

--- a/k8s/docs/08-release-notes/operator-1.0.0.md
+++ b/k8s/docs/08-release-notes/operator-1.0.0.md
@@ -80,56 +80,56 @@ kubectl tg create --cluster-name ${YOUR_CLUSTER_NAME} -n ${NAMESPACE_OF_CLUSTER}
 
 ## New features
 
-- Support customizing and updating TigerGraph configurations via TigerGraph CR or kubectl-tg plugin([TP-4166](https://graphsql.atlassian.net/browse/TP-4166) and [TP-4189](https://graphsql.atlassian.net/browse/TP-4189))
+- Support customizing and updating TigerGraph configurations via TigerGraph CR or kubectl-tg plugin.
 
-- Support pausing and resuming TigerGraph cluster ([TP-4263](https://graphsql.atlassian.net/browse/TP-4263))
+- Support pausing and resuming TigerGraph cluster.
 
-- Support customizing SecurityContext of TigerGraph ([TP-4515](https://graphsql.atlassian.net/browse/TP-4515))
+- Support customizing SecurityContext of TigerGraph.
 
-- Support customizing labels and annotations of TigerGraph Pod ([TP-4309](https://graphsql.atlassian.net/browse/TP-4309))
+- Support customizing labels and annotations of TigerGraph Pod.
 
-- Support Lifecycle hooks for TigerGraph CR: postInitAction ([TP-4308](https://graphsql.atlassian.net/browse/TP-4308))
+- Support Lifecycle hooks for TigerGraph CR: postInitAction.
 
-- Support mounting multiple PVC and PV for pods of TG（[TP-3590](https://graphsql.atlassian.net/browse/TP-3590))
+- Support mounting multiple PVC and PV for pods of TG.
 
-- Support customized volume mounts for TG container([TP-4352](https://graphsql.atlassian.net/browse/TP-4352))
+- Support customized volume mounts for TG container.
 
-- Support configuring additional storage and custom volume mounts of the TG container in kubectl-tg plugin([TP-4363](https://graphsql.atlassian.net/browse/TP-4363))
+- Support configuring additional storage and custom volume mounts of the TG container in kubectl-tg plugin.
 
-- Support customizing ingressClassName of ingress external service([TP-4244](https://graphsql.atlassian.net/browse/TP-4244))
+- Support customizing ingressClassName of ingress external service.
 
-- Support customizing custom volume with a new option --custom-volume in kubectl-tg plugin([TP-4531](https://graphsql.atlassian.net/browse/TP-4531))
+- Support customizing custom volume with a new option --custom-volume in kubectl-tg plugin.
 
-- Supports creating and updating clusters without external services via kubectl-tg([TP-4435](https://graphsql.atlassian.net/browse/TP-4435))
+- Supports creating and updating clusters without external services via kubectl-tg.
 
-- Supports independent modification of replication factor via TigerGraph CR([TP-4443](https://graphsql.atlassian.net/browse/TP-4443)) and kubectl-tg plugin([TP-4448](https://graphsql.atlassian.net/browse/TP-4448))
+- Supports independent modification of replication factor via TigerGraph CR.
 
 ## Improvements
 
-- Improve state transitions of TigerGraph CR ([TP-4211](https://graphsql.atlassian.net/browse/TP-4211))
+- Improve state transitions of TigerGraph CR.
 
-- Remove the redundant configuration of Tigergraph CRD and refactor the status output([TP-3710](https://graphsql.atlassian.net/browse/TP-3710))
+- Remove the redundant configuration of Tigergraph CRD and refactor the status output.
 
-- Removing dynamic pod labels and RESTPP external service([TP-3623](https://graphsql.atlassian.net/browse/TP-3623)); kubectl-tg plugin updated accordingly([TP-3729](https://graphsql.atlassian.net/browse/TP-3729))
+- Removing dynamic pod labels and RESTPP external service.
 
-- Remove field spec.InitTGConfig and place its remaining fields into subfields of spec and Status([TP-4230](https://graphsql.atlassian.net/browse/TP-4230))
+- Remove field spec.InitTGConfig and place its remaining fields into subfields of spec and Status.
 
-- Remove the InitJob field to improve usability([TP-3585](https://graphsql.atlassian.net/browse/TP-3585))
+- Remove the InitJob field to improve usability.
 
-- Refactor and improve the status output of TG CR([TP-3740](https://graphsql.atlassian.net/browse/TP-3740))
+- Refactor and improve the status output of TG CR.
 
-- Improve TigerGraphBackup and TigerGraphRestore CRD([TP-3726](https://graphsql.atlassian.net/browse/TP-3726)))
+- Improve TigerGraphBackup and TigerGraphRestore CRD.
 
-- Removing the pods of scale down automatically after executing shrinking successfully([TP-4245](https://graphsql.atlassian.net/browse/TP-4245))
+- Removing the pods of scale down automatically after executing shrinking successfully.
 
-- Invokes switch_version.sh to switch new version of TG to decouple the DB upgrade business logic([TP-4291](https://graphsql.atlassian.net/browse/TP-4291))
+- Invokes switch_version.sh to switch new version of TG to decouple the DB upgrade business logic.
 
-- Improve the failover process of expansion/shrinking for the new error code of ETCD([TP-4360](https://graphsql.atlassian.net/browse/TP-4360))
+- Improve the failover process of expansion/shrinking for the new error code of ETCD.
 
-- Use `gadmin start all --local` to start local services([TP-4327](https://graphsql.atlassian.net/browse/TP-4327))
+- Use `gadmin start all --local` to start local services.
 
 ## Bugfixes
 
-- Fix the issue of readiness check when the license is expired([TP-4451](https://graphsql.atlassian.net/browse/TP-4451))
+- Fix the issue of readiness check when the license is expired.
 
-- Add retry logic when resetting services and apply new configuration during expansion/shrinking([TP-4588](https://graphsql.atlassian.net/browse/TP-4588) TigerGraph 3.10.0 and above required)
+- Add retry logic when resetting services and apply new configuration during expansion/shrinking.

--- a/k8s/docs/08-release-notes/operator-1.1.0.md
+++ b/k8s/docs/08-release-notes/operator-1.1.0.md
@@ -76,12 +76,12 @@ kubectl tg create --cluster-name ${YOUR_CLUSTER_NAME} -n ${NAMESPACE_OF_CLUSTER}
 
 ## Improvements
 
-- Support overlap between ConfigUpdate and ConfigUpdate. Now when a config-update job is running, users are able to change .spec.tigergraphConfig. After the running job completes, another config-update job will run to apply the changes.([TP-4699](https://graphsql.atlassian.net/browse/TP-4699))
+- Support overlap between ConfigUpdate and ConfigUpdate. Now when a config-update job is running, users are able to change .spec.tigergraphConfig. After the running job completes, another config-update job will run to apply the changes.
 
 ## Bugfixes
 
-- Kubectl-tg plugin cannot remove tigergraphConfig/podLabels/podAnnotations fields of TigerGraph CR.([TP-5091](https://graphsql.atlassian.net/browse/TP-5091))
+- Kubectl-tg plugin cannot remove tigergraphConfig/podLabels/podAnnotations fields of TigerGraph CR.
 
-- Fix the watch namespace update issue of the operator in kubectl-tg plugin.([TP-5280](https://graphsql.atlassian.net/browse/TP-5280))
+- Fix the watch namespace update issue of the operator in kubectl-tg plugin.
 
-- Fix the issue of Nginx DNS cache for tigergraph on K8s ([TP-5360](https://graphsql.atlassian.net/browse/TP-5360))
+- Fix the issue of Nginx DNS cache for TigerGraph on Kubernetes.

--- a/k8s/docs/08-release-notes/operator-1.1.1.md
+++ b/k8s/docs/08-release-notes/operator-1.1.1.md
@@ -76,12 +76,12 @@ kubectl tg create --cluster-name ${YOUR_CLUSTER_NAME} -n ${NAMESPACE_OF_CLUSTER}
 
 ## Improvements
 
-- Validate the format of the backup tag in Webhook ([TP-5374](https://graphsql.atlassian.net/browse/TP-5374))
+- Validate the format of the backup tag in Webhook.
 
-- Support setting the ExternalTrafficPolicy of external services to local or cluster based on the TG version in the operator ([TP-5425](https://graphsql.atlassian.net/browse/TP-5425))
+- Support setting the ExternalTrafficPolicy of external services to local or cluster based on the TG version in the operator.
 
 ## Bugfixes
 
-- Support values in JSON array format in field tigergraph.spec.tigergraphConfig ([TP-5365](https://graphsql.atlassian.net/browse/TP-5365))
+- Support values in JSON array format in field tigergraph.spec.tigergraphConfig.
 
-- Fixed the issue with running the gcollect command of TigerGraph on Kubernetes ([TP-6351](https://graphsql.atlassian.net/browse/TP-6351))
+- Fixed the issue with running the gcollect command of TigerGraph on Kubernetes.

--- a/k8s/docs/08-release-notes/operator-1.2.0.md
+++ b/k8s/docs/08-release-notes/operator-1.2.0.md
@@ -56,40 +56,40 @@ Refer to the documentation [How to upgrade TigerGraph Kubernetes Operator](../04
 
 ## New features
 
-- Support lifecycle hooks preDeleteAction and prePauseAction for TigerGraph CR [TP-4706](https://graphsql.atlassian.net/browse/TP-4706)
+- Support lifecycle hooks preDeleteAction and prePauseAction for TigerGraph CR.
 
-- Support expanding PVCs of TigerGraph CR automatically [TP-4853](https://graphsql.atlassian.net/browse/TP-4853)
+- Support expanding PVCs of TigerGraph CR automatically.
 
-- Support customizing MaxConcurrentReconciles of controllers in K8s operator [TP-5196](https://graphsql.atlassian.net/browse/TP-5196)
+- Support customizing MaxConcurrentReconciles of controllers in K8s operator.
 
-- Support the creation of services for sidecar containers [TP-4900](https://graphsql.atlassian.net/browse/TP-4900)
+- Support the creation of services for sidecar containers.
 
-- Support configuring sidecar service in kubectl-tg [TP-5067](https://graphsql.atlassian.net/browse/TP-5067)
+- Support configuring sidecar service in kubectl-tg.
 
-- Support Multi-AZ cluster resiliency for better high availability and efficient resource utilization [TP-4854](https://graphsql.atlassian.net/browse/TP-4854)
+- Support Multi-AZ cluster resiliency for better high availability and efficient resource utilization.
 
-- Support Configuring topologySpreadConstraints and region awareness in kubectl-tg  [TP-5272](https://graphsql.atlassian.net/browse/TP-5272)
+- Support Configuring topologySpreadConstraints and region awareness in kubectl-tg.
 
-- Support debugging mode in operator [TP-4884](https://graphsql.atlassian.net/browse/TP-4884)
+- Support debugging mode in operator.
 
 ## Improvements
 
-- Support controlling retry behavior of TigerGraphBackup/ TigerGraphRestore [TP-4736](https://graphsql.atlassian.net/browse/TP-4736)
+- Support controlling retry behavior of TigerGraphBackup/ TigerGraphRestore.
 
-- Record the actual tag of the backup package in TigerGraphBackup.Status and support deleting backup package when deleting TigerGraphBackup CR [TP-4738](https://graphsql.atlassian.net/browse/TP-4738)
+- Record the actual tag of the backup package in TigerGraphBackup.Status and support deleting backup package when deleting TigerGraphBackup CR.
 
-- Remove TigerGraphBackupSchedule’s dependence on K8s Cronjob [TP-4809](https://graphsql.atlassian.net/browse/TP-4809)
+- Remove TigerGraphBackupSchedule’s dependence on K8s Cronjob.
 
-- Add a new status NotReady to check if the services of TG are Online. [TP-4890](https://graphsql.atlassian.net/browse/TP-4890)
+- Add a new status NotReady to check if the services of TG are Online.
 
-- Validate the format of the backup tag in webhook [TP-5374](https://graphsql.atlassian.net/browse/TP-5374)
+- Validate the format of the backup tag in webhook.
 
-- Improve the config update process to avoid restarting all services [TP-4820](https://graphsql.atlassian.net/browse/TP-4820)
+- Improve the config update process to avoid restarting all services.
 
-- Support setting the ExternalTrafficPolicy of external services to local or cluster based on the TG version in the operator [TP-5425](https://graphsql.atlassian.net/browse/TP-5425)
+- Support setting the ExternalTrafficPolicy of external services to local or cluster based on the TG version in the operator.
 
 ## Bug Fixes
 
-- Support values in JSON array format in field `tigergraph.spec.tigergraphConfig` [TP-5359](https://graphsql.atlassian.net/browse/TP-5359)
+- Support values in JSON array format in field `tigergraph.spec.tigergraphConfig`.
 
-- GSE slow shutdown [CORE-3372](https://graphsql.atlassian.net/browse/CORE-3372)  
+- GSE slow shutdown.  

--- a/k8s/docs/08-release-notes/operator-1.3.0.md
+++ b/k8s/docs/08-release-notes/operator-1.3.0.md
@@ -25,7 +25,7 @@ sudo install kubectl-tg /usr/local/bin/
 There are no breaking changes in the TigerGraph CRDs for version 1.3.0 compared to versions 1.0.0 and above. You can upgrade the TigerGraph Operator by following these steps if an older version (1.0.0 or above) is installed.
 
 > [!NOTE]
-> There is currently no support for upgrading or deleting CRDs when upgrading or uninstalling the TigerGraph Operator due to the risk of unintentional data loss. It is necessary to upgrade TigerGraph CRDs manually for the operator version prior to 1.3.0. However, for operator version 1.3.0, we use [Helm chart’s pre-upgrade hook](https://helm.sh/docs/topics/charts_hooks/) to upgrade the CRDs automatically. You can ignore the first step if you upgrade the operator to version 1.3.0 or above.
+> There is currently no support for upgrading or deleting CRDs when upgrading or uninstalling the TigerGraph Operator due to the risk of unintentional data loss. It is necessary to upgrade TigerGraph CRDs manually for the operator version prior to 1.3.0. However, starting from Operator version 1.3.0, we use [Helm chart’s pre-upgrade hook](https://helm.sh/docs/topics/charts_hooks/) to upgrade the CRDs automatically. You can ignore the first step if you upgrade the operator to version 1.3.0 or above.
 
 Upgrade the TigerGraph CRDs to the latest version(It's required for the operator version prior to 1.3.0)
 
@@ -59,30 +59,30 @@ Refer to the documentation [How to upgrade TigerGraph Kubernetes Operator](../04
 
 ## New features
 
-- Operator 1.3.0 achieves GA for AKS, ensuring improved stability and support for Azure Kubernetes Service
+- Operator 1.3.0 achieves GA for AKS, ensuring improved stability and support for Azure Kubernetes Service.
 
-- Support for customizing external service port for TG listener and sidecar listener [TP-5759](https://graphsql.atlassian.net/browse/TP-5759)
+- Support for customizing external service port for TG listener and sidecar listener.
 
-- Add a pre-upgrade hook in operator helm chart to refresh CRD automatically during operator upgrade  [TP-6095](https://graphsql.atlassian.net/browse/TP-6095)
+- Add a pre-upgrade hook in operator helm chart to refresh CRD automatically during operator upgrade.
 
 ## Improvements
 
-- Add a new status Degraded in operator to indicate that a region-aware cluster is partially available [TP-6122](https://graphsql.atlassian.net/browse/TP-6122)
+- Add a new status Degraded in operator to indicate that a region-aware cluster is partially available.
 
-- Make the maximum number of retries for the init-job configurable via annotations [TP-6104](https://graphsql.atlassian.net/browse/TP-6104)
+- Make the maximum number of retries for the init-job configurable via annotations.
 
-- Add namespace as a suffix of HostName in HostList on K8s [TP-5776](https://graphsql.atlassian.net/browse/TP-5776)
+- Add namespace as a suffix of HostName in HostList on K8s.
 
-- Support for configuring nodeSelector for operator pods [TP-5395](https://graphsql.atlassian.net/browse/TP-5395)
+- Support for configuring nodeSelector for operator pods.
 
-- Avoid too many events on SuccessfulDeleteService [TP-4564](https://graphsql.atlassian.net/browse/TP-4564)
+- Avoid too many events on SuccessfulDeleteService.
 
-- Improve log of Operator Jobs by removing redundant gadmin output [TP-5603](https://graphsql.atlassian.net/browse/TP-5603)
+- Improve log of Operator Jobs by removing redundant gadmin output.
 
 ## Bug Fixes
 
-- Inconsistent precheck error message for a non-region-aware cluster in k8s operator [TP-5669](https://graphsql.atlassian.net/browse/TP-5669)
+- Inconsistent pre-check error message for a non-region-aware cluster in k8s operator.
 
-- Verify the existence of S3 secret for restoring from s3 [TP-4111](https://graphsql.atlassian.net/browse/TP-4111)
+- Verify the existence of S3 secret for restoring from s3.
 
-- Don't set default backup compress process number [TP-6179](https://graphsql.atlassian.net/browse/TP-6179)
+- Don't set default backup compress process number.

--- a/k8s/docs/08-release-notes/operator-1.4.0.md
+++ b/k8s/docs/08-release-notes/operator-1.4.0.md
@@ -1,0 +1,86 @@
+# TigerGraph Operator 1.4.0 Release notes
+
+## Overview
+
+**TigerGraph Operator 1.4.0** is now available, designed to work seamlessly with **TigerGraph version 4.1.2**.
+
+This release introduces significant improvements and bug fixes, including:
+
+- Support for customizing pod labels and annotations in the PodTemplateSpec of the StatefulSet managing TigerGraph pods.
+
+- Support for retaining the last successfully scheduled backup CR in case the latest scheduled backups consistently fail
+
+- Support for restoring clusters even when they are in a NotReady or Degraded state.
+
+- Resolve the issue of inconsistent host lists during configuration updates with region awareness enabled.
+
+- Fix the issue causing a rolling update to be triggered when the cluster is in a NotReady or Degraded state.
+
+- Fix an issue where the file system owner could not be changed to user tigergraph during TigerGraph Init Container execution.
+
+- Fix an issue of label and annotation parsing in kubectl-tg plugin.
+
+For more details, refer to the section below.
+
+> [!IMPORTANT]
+> TigerGraph Operator has had a breaking change since version 1.0.0. If you are still using a version older than 1.0.0, it is strongly recommended that you upgrade to version 1.4.0. Versions older than 1.0.0 have been deprecated.
+
+### kubectl plugin installation
+
+To install the kubectl plugin for TigerGraph Operator 1.4.0, execute the following command:
+
+```bash
+curl https://dl.tigergraph.com/k8s/1.4.0/kubectl-tg  -o kubectl-tg
+sudo install kubectl-tg /usr/local/bin/
+```
+
+### TigerGraph Operator upgrading
+
+#### Upgrading from TigerGraph Operator 1.0.0 and later versions to version 1.4.0
+
+There are no breaking changes in the TigerGraph CRDs for version 1.4.0 compared to versions 1.0.0 and above. You can upgrade the TigerGraph Operator by following these steps if an older version (1.0.0 or above) is installed.
+
+> [!NOTE]
+> There is currently no support for upgrading or deleting CRDs when upgrading or uninstalling the TigerGraph Operator due to the risk of unintentional data loss. It is necessary to upgrade TigerGraph CRDs manually for the operator version prior to 1.3.0. However, starting from Operator version 1.3.0, we use [Helm chart’s pre-upgrade hook](https://helm.sh/docs/topics/charts_hooks/) to upgrade the CRDs automatically. You can ignore the first step if you upgrade the operator to version 1.3.0 or above.
+
+> [!IMPORTANT]
+> Please ensure that you have installed the `kubectl-tg` version 1.4.0 before upgrading TigerGraph Operator to version 1.4.0.
+
+Ensure you have installed the correct version of kubectl-tg:
+
+```bash
+kubectl tg version
+
+Version: 1.4.0
+Default version of TigerGraph cluster: 4.1.2
+```
+
+Upgrade TigerGraph Operator using kubectl-tg plugin:
+
+```bash
+kubectl tg upgrade --namespace ${YOUR_NAMESPACE_OF_OPERATOR} --operator-version 1.4.0
+```
+
+#### Upgrading from TigerGraph Operator versions prior to 1.0.0 to version 1.0.0 and above
+
+This TigerGraph Operator version upgrade introduces breaking changes if you are upgrading from TigerGraph Operator versions prior to 1.0.0. You need to upgrade the TigerGraph Operator, CRD, and the TigerGraph cluster following specific steps.
+
+Refer to the documentation [How to upgrade TigerGraph Kubernetes Operator](../04-manage/operator-upgrade.md) for details.
+
+## Improvements
+
+- Support for customizing pod labels and annotations in the PodTemplateSpec of the StatefulSet managing TigerGraph pods.
+
+- Support for retaining the last successfully scheduled backup CR in case the latest scheduled backups consistently fail.
+
+- Support restoring the cluster when it is in NotReady or Degraded status.
+
+## Bug Fixes
+
+- Resolve the issue of inconsistent host lists during configuration updates with region awareness enabled.
+
+- Fix the issue causing a rolling update to be triggered when the cluster is in a NotReady or Degraded state.
+
+- Fix an issue where the file system owner could not be changed to user tigergraph during TigerGraph Init Container execution.
+
+- Fix an issue of label and annotation parsing in kubectl-tg plugin.


### PR DESCRIPTION
At a minimum please provide the following:

### Description of the Change

Update K8s docs for Operator 1.4.0.

### Release Notes

**TigerGraph Operator 1.4.0** is now available, designed to work seamlessly with **TigerGraph version 4.1.2**.

This release introduces significant improvements and bug fixes, including:

- Support for customizing pod labels and annotations in the PodTemplateSpec of the StatefulSet managing TigerGraph pods.

- Support for retaining the last successfully scheduled backup CR in case the latest scheduled backups consistently fail

- Support for restoring clusters even when they are in a NotReady or Degraded state.

- Resolve the issue of inconsistent host lists during configuration updates with region awareness enabled.

- Fix the issue causing a rolling update to be triggered when the cluster is in a NotReady or Degraded state.

- Fix an issue where the file system owner could not be changed to user tigergraph during TigerGraph Init Container execution.

- Fix an issue of label and annotation parsing in kubectl-tg plugin.
